### PR TITLE
Support 3D CNNs for Distconv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,8 @@ mark_as_advanced(LBANN_WARNINGS_AS_ERRORS)
 option(LBANN_WITH_DISTCONV
   "Enable Distconv distributed convolution" OFF)
 
+set(LBANN_DISTCONV_NUM_DIMS 4 CACHE STRING "The number of tensor dimensions")
+
 option(LBANN_WITH_P2P
   "Enable P2P library" OFF)
 
@@ -415,7 +417,7 @@ if (LBANN_WITH_DISTCONV)
   message(STATUS "DISTCONV requested")
   find_package(P2P)
   find_package(DISTCONV)
-  set(LBANN_HAS_DISTCONV ${DISTCONV_FOUND}) 
+  set(LBANN_HAS_DISTCONV ${DISTCONV_FOUND})
   if (NOT LBANN_HAS_DISTCONV)
     message(FATAL_ERROR
       "Requested LBANN_WITH_DISTCONV but Distconv not found. "
@@ -423,7 +425,7 @@ if (LBANN_WITH_DISTCONV)
       "Try specifying DISTCONV_DIR as the root of a DISTCONV install. "
       "Alternatively, build with LBANN_WITH_DISTCONV=OFF.")
     set(LBANN_WITH_DISTCONV OFF)
-  endif(NOT LBANN_HAS_DISTCONV)      
+  endif(NOT LBANN_HAS_DISTCONV)
   if (NOT P2P_FOUND)
     message(FATAL_ERROR
       "Requested LBANN_WITH_DISTCONV but its required package, P2P, not found. "
@@ -432,6 +434,10 @@ if (LBANN_WITH_DISTCONV)
       "Alternatively, build with LBANN_WITH_DISTCONV=OFF.")
     set(LBANN_WITH_DISTCONV OFF)
   endif(NOT P2P_FOUND)
+endif (LBANN_WITH_DISTCONV)
+
+if (LBANN_WITH_DISTCONV)
+  add_definitions(-DLBANN_DISTCONV_NUM_DIMS=${LBANN_DISTCONV_NUM_DIMS})
 endif (LBANN_WITH_DISTCONV)
 
 # Handle the documentation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,10 +436,6 @@ if (LBANN_WITH_DISTCONV)
   endif(NOT P2P_FOUND)
 endif (LBANN_WITH_DISTCONV)
 
-if (LBANN_WITH_DISTCONV)
-  add_definitions(-DLBANN_DISTCONV_NUM_DIMS=${LBANN_DISTCONV_NUM_DIMS})
-endif (LBANN_WITH_DISTCONV)
-
 # Handle the documentation
 add_subdirectory(docs)
 

--- a/cmake/configure_files/lbann_config.hpp.in
+++ b/cmake/configure_files/lbann_config.hpp.in
@@ -45,6 +45,18 @@
 /* Defined if LBANN has Distconv */
 #cmakedefine LBANN_HAS_DISTCONV
 
+#ifdef LBANN_HAS_DISTCONV
+#cmakedefine LBANN_DISTCONV_NUM_DIMS @LBANN_DISTCONV_NUM_DIMS@
+
+#if LBANN_DISTCONV_NUM_DIMS == 5
+#define LBANN_DISTCONV_HAS_DEPTH
+#elif LBANN_DISTCONV_NUM_DIMS == 4
+#else
+#error Only 4 or 5 are supported for LBANN_DISTCONV_NUM_DIMS.
+#endif
+
+#endif
+
 // Define the LBANN datatype
 namespace lbann
 {

--- a/include/lbann/layers/activations/relu.hpp
+++ b/include/lbann/layers/activations/relu.hpp
@@ -1,5 +1,3 @@
-// REVIEW: distconv-3d
-
 ////////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory.

--- a/include/lbann/layers/activations/relu.hpp
+++ b/include/lbann/layers/activations/relu.hpp
@@ -61,7 +61,7 @@ protected:
 
  public:
   void setup_tensor_distribution_init(
-      std::map<const Layer*, std::array<dc::Dist, dc::num_dims>> &dists,
+      std::map<const Layer*, std::array<dc::Dist, 4>> &dists,
       std::map<dc::Dist*, std::set<dc::Dist*>> &invariants,
       std::set<dc::Dist*> &updated,
       std::set<dc::Dist*> &fixed) override {
@@ -69,11 +69,11 @@ protected:
         dists, invariants, updated, fixed);
   }
 
-  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
     Layer::setup_tensors_fwd(dists);
   }
 
-  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
     Layer::setup_tensors_bwd(dists);
   }
 

--- a/include/lbann/layers/activations/relu.hpp
+++ b/include/lbann/layers/activations/relu.hpp
@@ -61,7 +61,7 @@ protected:
 
  public:
   void setup_tensor_distribution_init(
-      std::map<const Layer*, std::array<dc::Dist, 4>> &dists,
+      std::map<const Layer*, std::array<dc::Dist, dc::num_dists>> &dists,
       std::map<dc::Dist*, std::set<dc::Dist*>> &invariants,
       std::set<dc::Dist*> &updated,
       std::set<dc::Dist*> &fixed) override {
@@ -69,11 +69,11 @@ protected:
         dists, invariants, updated, fixed);
   }
 
-  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     Layer::setup_tensors_fwd(dists);
   }
 
-  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     Layer::setup_tensors_bwd(dists);
   }
 

--- a/include/lbann/layers/activations/relu.hpp
+++ b/include/lbann/layers/activations/relu.hpp
@@ -1,3 +1,5 @@
+// REVIEW: distconv-3d
+
 ////////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory.
@@ -59,7 +61,7 @@ protected:
 
  public:
   void setup_tensor_distribution_init(
-      std::map<const Layer*, std::array<dc::Dist, 4>> &dists,
+      std::map<const Layer*, std::array<dc::Dist, dc::num_dims>> &dists,
       std::map<dc::Dist*, std::set<dc::Dist*>> &invariants,
       std::set<dc::Dist*> &updated,
       std::set<dc::Dist*> &fixed) override {
@@ -67,11 +69,11 @@ protected:
         dists, invariants, updated, fixed);
   }
 
-  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
     Layer::setup_tensors_fwd(dists);
   }
 
-  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
     Layer::setup_tensors_bwd(dists);
   }
 

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -56,7 +56,6 @@ struct ParallelStrategy {
   int sample_groups = 0;
   /** Number of groups the sample dimension is split over. */
   int sample_splits = 0;
-  // TODO: distconv-3d, do not define if num_dims == 4
   /** Number of process groups the depth dimension is split over. */
   int depth_groups = 0;
   /** Number of groups the depth dimension is split over. */

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -552,26 +552,26 @@ protected:
   void setup_early_termination();
   void setup_keep_original_tensors();
   virtual void setup_tensor_distribution_init(
-      std::map<const Layer*, std::array<lbann::dc::Dist, 4>> &dists,
+      std::map<const Layer*, std::array<dc::Dist, dc::num_dists>> &dists,
       std::map<dc::Dist*, std::set<dc::Dist*>> &invariants,
       std::set<dc::Dist*> &updated,
       std::set<dc::Dist*> &fixed);
   virtual void setup_tensor_distribution_add_adjacent_invariants(
-      std::map<const Layer*, std::array<dc::Dist, 4>> &dists,
+      std::map<const Layer*, std::array<dc::Dist, dc::num_dists>> &dists,
       std::map<dc::Dist*, std::set<dc::Dist*>> &invariants);
   virtual void setup_tensor_distribution_block();
-  virtual size_t estimate_memory_usage(const std::array<dc::Dist, 4> &dists);
-  virtual void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) {}
-  virtual void setup_prev_activations_tensor(const std::array<dc::Dist, 4> &dists);
+  virtual size_t estimate_memory_usage(const std::array<dc::Dist, dc::num_dists> &dists);
+  virtual void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dists> &dists) {}
+  virtual void setup_prev_activations_tensor(const std::array<dc::Dist, dc::num_dists> &dists);
   virtual dc::ArrayND get_activations_tensor_local_shape() const;
-  virtual void setup_activations_tensor(const std::array<dc::Dist, 4> &dists,
+  virtual void setup_activations_tensor(const std::array<dc::Dist, dc::num_dists> &dists,
                                         bool allocate=true);
-  virtual void setup_activations_copyout_tensor(const std::array<dc::Dist, 4> &dists);
-  virtual void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists);
+  virtual void setup_activations_copyout_tensor(const std::array<dc::Dist, dc::num_dists> &dists);
+  virtual void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dists> &dists);
   virtual void setup_distconv_post(size_t ws_size);
-  virtual void setup_prev_error_signals_tensor(const std::array<dc::Dist, 4> &dists);
-  virtual void setup_error_signals_tensor(const std::array<dc::Dist, 4> &dists);
-  virtual void setup_error_signals_copyout_tensor(const std::array<dc::Dist, 4> &dists);
+  virtual void setup_prev_error_signals_tensor(const std::array<dc::Dist, dc::num_dists> &dists);
+  virtual void setup_error_signals_tensor(const std::array<dc::Dist, dc::num_dists> &dists);
+  virtual void setup_error_signals_copyout_tensor(const std::array<dc::Dist, dc::num_dists> &dists);
   virtual dc::ArrayND get_prev_activations_overlap() const;
   virtual dc::ArrayND get_activations_overlap() const;
   virtual dc::ArrayND get_prev_error_signals_overlap() const;

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -543,7 +543,7 @@ protected:
   void setup_early_termination();
   void setup_keep_original_tensors();
   virtual void setup_tensor_distribution_init(
-      std::map<const Layer*, std::array<lbann::dc::Dist, 4>> &dists, 
+      std::map<const Layer*, std::array<lbann::dc::Dist, 4>> &dists,
       std::map<dc::Dist*, std::set<dc::Dist*>> &invariants,
       std::set<dc::Dist*> &updated,
       std::set<dc::Dist*> &fixed);
@@ -554,21 +554,21 @@ protected:
   virtual size_t estimate_memory_usage(const std::array<dc::Dist, 4> &dists);
   virtual void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) {}
   virtual void setup_prev_activations_tensor(const std::array<dc::Dist, 4> &dists);
-  virtual dc::Array4 get_activations_tensor_local_shape() const;
+  virtual dc::ArrayND get_activations_tensor_local_shape() const;
   virtual void setup_activations_tensor(const std::array<dc::Dist, 4> &dists,
                                         bool allocate=true);
-  virtual void setup_activations_copyout_tensor(const std::array<dc::Dist, 4> &dists);  
+  virtual void setup_activations_copyout_tensor(const std::array<dc::Dist, 4> &dists);
   virtual void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists);
   virtual void setup_distconv_post(size_t ws_size);
   virtual void setup_prev_error_signals_tensor(const std::array<dc::Dist, 4> &dists);
   virtual void setup_error_signals_tensor(const std::array<dc::Dist, 4> &dists);
   virtual void setup_error_signals_copyout_tensor(const std::array<dc::Dist, 4> &dists);
-  virtual dc::Array4 get_prev_activations_overlap() const;
-  virtual dc::Array4 get_activations_overlap() const;  
-  virtual dc::Array4 get_prev_error_signals_overlap() const;
-  virtual dc::Array4 get_error_signals_overlap() const;
-  virtual dc::Array4 get_input_decomposition_block() const;
-  virtual dc::Array4 get_output_decomposition_block() const;
+  virtual dc::ArrayND get_prev_activations_overlap() const;
+  virtual dc::ArrayND get_activations_overlap() const;
+  virtual dc::ArrayND get_prev_error_signals_overlap() const;
+  virtual dc::ArrayND get_error_signals_overlap() const;
+  virtual dc::ArrayND get_input_decomposition_block() const;
+  virtual dc::ArrayND get_output_decomposition_block() const;
 #if 0
   virtual const dc::Dist &get_prev_activations_distribution() const {
     return m_prev_activations_dist;
@@ -583,10 +583,10 @@ protected:
     return m_error_signals_dist;
   }
 #endif
-  
+
   // REFACTORING: returning non-const tensor should be protected
   virtual const dc::TensorDev &get_activations_t() const;
-  virtual const dc::TensorDev &get_error_signals_t() const;  
+  virtual const dc::TensorDev &get_error_signals_t() const;
   //virtual ConstTensorDev get_activations_const_view() const;
   //virtual ConstTensorDev get_prev_activations_const_view() const;
 
@@ -596,14 +596,14 @@ protected:
   void disable_distconv() {
     m_distconv_enabled = false;
   }
-  
+
  protected:
   virtual bool keep_original_input() const { return m_keep_original_input; }
   virtual bool keep_original_output() const { return m_keep_original_output; }
   virtual void fp_setup_distconv(int mini_batch_size);
-  virtual void bp_setup_distconv(int mini_batch_size);  
-  
-  virtual dc::Array4 get_strides() const;
+  virtual void bp_setup_distconv(int mini_batch_size);
+
+  virtual dc::ArrayND get_strides() const;
 
   // Copis and converts input or output tensors when necessary
   void ensure_prev_activations();
@@ -646,13 +646,13 @@ protected:
     dump_tensor(m_error_signals_copyout,
                 get_name() + "_error_signals_original");
   }
-  
+
   bool m_parent_copy_in_required = false;
   bool m_parent_shuffle_required = false;
   bool m_child_copy_out_required = false;
-  bool m_child_shuffle_required = false;  
-  dc::Array4 m_input_decomposition_block;
-  dc::Array4 m_output_decomposition_block;  
+  bool m_child_shuffle_required = false;
+  dc::ArrayND m_input_decomposition_block;
+  dc::ArrayND m_output_decomposition_block;
   /** Previous activation tensor */
   dc::TensorDev m_prev_activations_t;
   /** View to Elemental matrix of previous activations */

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -56,10 +56,12 @@ struct ParallelStrategy {
   int sample_groups = 0;
   /** Number of groups the sample dimension is split over. */
   int sample_splits = 0;
+#ifdef DISTCONV_HAS_DEPTH
   /** Number of process groups the depth dimension is split over. */
   int depth_groups = 0;
   /** Number of groups the depth dimension is split over. */
   int depth_splits = 0;
+#endif
   /** Number of process groups the height dimension is split over. */
   int height_groups = 0;
   /** Number of groups the height dimension is split over. */
@@ -81,8 +83,10 @@ struct ParallelStrategy {
   bool operator==(const ParallelStrategy &ps) const {
     return sample_groups == ps.sample_groups &&
         sample_splits == ps.sample_splits &&
+#ifdef DISTCONV_HAS_DEPTH
         depth_groups == ps.depth_groups &&
         depth_splits == ps.depth_splits &&
+#endif
         height_groups == ps.height_groups &&
         height_splits == ps.height_splits &&
         width_groups == ps.width_groups &&
@@ -102,8 +106,10 @@ inline std::ostream &operator<<(std::ostream &os,
                                 const ParallelStrategy &ps) {
   os << "{" << ps.sample_groups
      << "/" << ps.sample_splits
+#ifdef DISTCONV_HAS_DEPTH
      << ", " << ps.depth_groups
      << "/" << ps.depth_splits
+#endif
      << ", " << ps.height_groups
      << "/" << ps.height_splits
      << ", " << ps.width_groups

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -56,7 +56,7 @@ struct ParallelStrategy {
   int sample_groups = 0;
   /** Number of groups the sample dimension is split over. */
   int sample_splits = 0;
-#ifdef DISTCONV_HAS_DEPTH
+#ifdef LBANN_DISTCONV_HAS_DEPTH
   /** Number of process groups the depth dimension is split over. */
   int depth_groups = 0;
   /** Number of groups the depth dimension is split over. */
@@ -83,7 +83,7 @@ struct ParallelStrategy {
   bool operator==(const ParallelStrategy &ps) const {
     return sample_groups == ps.sample_groups &&
         sample_splits == ps.sample_splits &&
-#ifdef DISTCONV_HAS_DEPTH
+#ifdef LBANN_DISTCONV_HAS_DEPTH
         depth_groups == ps.depth_groups &&
         depth_splits == ps.depth_splits &&
 #endif
@@ -106,7 +106,7 @@ inline std::ostream &operator<<(std::ostream &os,
                                 const ParallelStrategy &ps) {
   os << "{" << ps.sample_groups
      << "/" << ps.sample_splits
-#ifdef DISTCONV_HAS_DEPTH
+#ifdef LBANN_DISTCONV_HAS_DEPTH
      << ", " << ps.depth_groups
      << "/" << ps.depth_splits
 #endif
@@ -686,7 +686,6 @@ private:
   /** Return Distconv-related shapes. */
   const dc::Shape get_input_tensor_shape() const;
   const dc::Shape get_output_tensor_shape() const;
-  const dc::Shape get_sample_block_size() const;
 
   // ===========================================================
   // Private class members

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -56,6 +56,11 @@ struct ParallelStrategy {
   int sample_groups = 0;
   /** Number of groups the sample dimension is split over. */
   int sample_splits = 0;
+  // TODO: distconv-3d, do not define if num_dims == 4
+  /** Number of process groups the depth dimension is split over. */
+  int depth_groups = 0;
+  /** Number of groups the depth dimension is split over. */
+  int depth_splits = 0;
   /** Number of process groups the height dimension is split over. */
   int height_groups = 0;
   /** Number of groups the height dimension is split over. */
@@ -77,6 +82,8 @@ struct ParallelStrategy {
   bool operator==(const ParallelStrategy &ps) const {
     return sample_groups == ps.sample_groups &&
         sample_splits == ps.sample_splits &&
+        depth_groups == ps.depth_groups &&
+        depth_splits == ps.depth_splits &&
         height_groups == ps.height_groups &&
         height_splits == ps.height_splits &&
         width_groups == ps.width_groups &&
@@ -96,6 +103,8 @@ inline std::ostream &operator<<(std::ostream &os,
                                 const ParallelStrategy &ps) {
   os << "{" << ps.sample_groups
      << "/" << ps.sample_splits
+     << ", " << ps.depth_groups
+     << "/" << ps.depth_splits
      << ", " << ps.height_groups
      << "/" << ps.height_splits
      << ", " << ps.width_groups
@@ -693,6 +702,11 @@ private:
   const AbsDistMat& get_activations(const Layer& child) const;
   /** Get error signal tensor corresponding to parent layer. */
   const AbsDistMat& get_error_signals(const Layer& parent) const;
+
+  /** Return Distconv-related shapes. */
+  const dc::ArrayND get_input_tensor_shape() const;
+  const dc::ArrayND get_output_tensor_shape() const;
+  const dc::ArrayND get_sample_block_size() const;
 
   // ===========================================================
   // Private class members

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -374,7 +374,7 @@ protected:
           * this->m_dilations[0];
       int stencil_w = (this->m_kernel_dims[3] - 1) / 2
           * this->m_dilations[1];
-      dc::Array4 overlap(0);
+      dc::IntVector overlap(4, 0);
       if (this->get_parallel_strategy().width_splits > 1) {
         overlap[0] = stencil_w;
       }

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -367,7 +367,7 @@ protected:
   }
 
   void setup_tensor_distribution_init(
-      std::map<const Layer*, std::array<dc::Dist, 4>> &dists,
+      std::map<const Layer*, std::array<dc::Dist, dc::num_dists>> &dists,
       std::map<dc::Dist*, std::set<dc::Dist*>> &invariants,
       std::set<dc::Dist*> &updated,
       std::set<dc::Dist*> &fixed) override {
@@ -422,7 +422,7 @@ protected:
   }
 
   // REVIEW: distconv-3d
-  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     using namespace dc;
     Layer::setup_tensors_fwd(dists);
     if (!this->distconv_enabled()) return;
@@ -481,7 +481,7 @@ protected:
   }
 
   // REVIEW: distconv-3d
-  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     Layer::setup_tensors_bwd(dists);
     if (!this->distconv_enabled()) return;
 

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -368,7 +368,7 @@ protected:
   }
 
   void setup_tensor_distribution_init(
-      std::map<const Layer*, std::array<dc::Dist, dc::num_dims>> &dists,
+      std::map<const Layer*, std::array<dc::Dist, 4>> &dists,
       std::map<dc::Dist*, std::set<dc::Dist*>> &invariants,
       std::set<dc::Dist*> &updated,
       std::set<dc::Dist*> &fixed) override {
@@ -423,7 +423,7 @@ protected:
   }
 
   // REVIEW: distconv-3d
-  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
     using namespace dc;
     Layer::setup_tensors_fwd(dists);
     if (!this->distconv_enabled()) return;
@@ -482,7 +482,7 @@ protected:
   }
 
   // REVIEW: distconv-3d
-  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
     Layer::setup_tensors_bwd(dists);
     if (!this->distconv_enabled()) return;
 

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -356,7 +356,6 @@ protected:
             {this->get_parallel_strategy().height_splits,
              this->get_parallel_strategy().width_splits})[i];
 #endif // DISTCONV_HAS_DEPTH
-        assert(splits != -1);
         if(splits > 1)
           overlap[dc::num_spatial_dims - 1 - i] = (this->m_kernel_dims[2 + i] - 1) / 2 * this->m_dilations[i];
       }

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -344,7 +344,6 @@ protected:
     Layer::setup_tensor_distribution_init(
         dists, invariants, updated, fixed);
     if (this->distconv_enabled()) {
-      // REVIEW: distconv-3d
       dc::IntVector overlap(dc::num_dims, 0);
       for(int i = 0; i < dc::num_spatial_dims; i++) {
         const int splits = std::vector<int>(
@@ -391,7 +390,6 @@ protected:
     return output_spatial_local_shape;
   }
 
-  // REVIEW: distconv-3d
   void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     using namespace dc;
     Layer::setup_tensors_fwd(dists);
@@ -507,7 +505,6 @@ protected:
   bool using_distconv() const override {
     if (!Layer::using_distconv()) return false;
 
-    // REVIEW: distconv-3d
     bool cond = true;
     for(int i = 0; i < dc::num_spatial_dims; i++) {
       cond &= this->m_kernel_dims[2 + i] == this->m_kernel_dims[2];

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -346,14 +346,16 @@ protected:
     if (this->distconv_enabled()) {
       dc::IntVector overlap(dc::num_dims, 0);
       for(int i = 0; i < dc::num_spatial_dims; i++) {
+#ifdef DISTCONV_HAS_DEPTH
+        const int splits = std::vector<int>(
+            {this->get_parallel_strategy().depth_splits,
+             this->get_parallel_strategy().height_splits,
+             this->get_parallel_strategy().width_splits})[i];
+#else
         const int splits = std::vector<int>(
             {this->get_parallel_strategy().height_splits,
-             this->get_parallel_strategy().width_splits,
-             -1,
-             this->get_parallel_strategy().depth_splits,
-             this->get_parallel_strategy().height_splits,
-             this->get_parallel_strategy().width_splits})
-            [i + 3 * (dc::num_dims - 4)];
+             this->get_parallel_strategy().width_splits})[i];
+#endif // DISTCONV_HAS_DEPTH
         assert(splits != -1);
         if(splits > 1)
           overlap[dc::num_spatial_dims - 1 - i] = (this->m_kernel_dims[2 + i] - 1) / 2 * this->m_dilations[i];

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -148,6 +148,7 @@ public:
       LBANN_ERROR(err.str());
     }
 
+    // FIXME: distconv-3d
     // Initialize output tensor dimensions
     output_dims[0] = output_channels;
     for (size_t i = 0; i < output_dims.size() - 1; ++i) {
@@ -336,30 +337,31 @@ protected:
 #ifdef LBANN_HAS_DISTCONV
  public:
 
-  dc::Array4 get_prev_activations_overlap() const override {
+  dc::ArrayND get_prev_activations_overlap() const override {
     if (this->distconv_enabled()) {
+      // FIXME: distconv-3d
       int stencil_h = (this->m_kernel_dims[2] - 1) / 2;
       int stencil_w = (this->m_kernel_dims[3] - 1) / 2;
-      return dc::Array4({stencil_w, stencil_h, 0, 0});
+      return dc::ArrayND({stencil_w, stencil_h, 0, 0});
     } else {
-      return dc::Array4(0);
+      return dc::ArrayND(0);
     }
   }
 
-  dc::Array4 get_activations_overlap() const override {
-    return dc::Array4(0);
+  dc::ArrayND get_activations_overlap() const override {
+    return dc::ArrayND(0);
   }
 
-  dc::Array4 get_prev_error_signals_overlap() const override {
+  dc::ArrayND get_prev_error_signals_overlap() const override {
     if (this->distconv_enabled()) {
       return get_prev_activations_overlap();
     } else {
-      return dc::Array4(0);
+      return dc::ArrayND(0);
     }
   }
 
-  dc::Array4 get_error_signals_overlap() const override {
-    return dc::Array4(0);
+  dc::ArrayND get_error_signals_overlap() const override {
+    return dc::ArrayND(0);
   }
 
   void setup_tensor_distribution_init(
@@ -370,11 +372,12 @@ protected:
     Layer::setup_tensor_distribution_init(
         dists, invariants, updated, fixed);
     if (this->distconv_enabled()) {
+      // FIXME: distconv-3d
       int stencil_h = (this->m_kernel_dims[2] - 1) / 2
           * this->m_dilations[0];
       int stencil_w = (this->m_kernel_dims[3] - 1) / 2
           * this->m_dilations[1];
-      dc::Array4 overlap(0);
+      dc::ArrayND overlap(0);
       if (this->get_parallel_strategy().width_splits > 1) {
         overlap[0] = stencil_w;
       }
@@ -398,14 +401,14 @@ protected:
     }
   }
 
-  dc::Array4 get_activations_tensor_local_shape() const override {
+  dc::ArrayND get_activations_tensor_local_shape() const override {
     std::vector<int> filter_dims = this->m_kernel_dims;
     std::reverse(filter_dims.begin(), filter_dims.end());
     std::vector<int> strides = this->m_strides;
     std::reverse(strides.begin(), strides.end());
     std::vector<int> dilations = this->m_dilations;
     std::reverse(dilations.begin(), dilations.end());
-    const dc::Array4 output_spatial_local_shape =
+    const dc::ArrayND output_spatial_local_shape =
         ::distconv::get_convolution_output_local_tensor_shape(
             this->m_prev_activations_t,
             filter_dims, strides, true, dilations,
@@ -417,6 +420,7 @@ protected:
     using namespace dc;
     Layer::setup_tensors_fwd(dists);
     if (!this->distconv_enabled()) return;
+    // FIXME: distconv-3d
 
     std::stringstream ss;
     util::print_vector(ss, this->m_kernel_dims.begin(), this->m_kernel_dims.end());
@@ -451,7 +455,7 @@ protected:
         << dc::util::tostring(this->m_bias_cudnn_desc)
         << ", bias factor: " << this->m_bias_scaling_factor;
     if (this->m_bias_scaling_factor != DataType(0)) {
-      Array4 bias_shape = {1, 1, this->get_output_dims()[0], 1};
+      ArrayND bias_shape = {1, 1, this->get_output_dims()[0], 1};
       m_bias_t = TensorDev(bias_shape, loc, shared_dist);
       assert0(tensor::View(m_bias_t,
                            this->get_weights()[1]->get_values().LockedBuffer()));
@@ -526,6 +530,7 @@ protected:
   bool using_distconv() const override {
     if (!Layer::using_distconv()) return false;
 
+    // FIXME: distconv-3d
     if (!(this->m_kernel_dims[2] == this->m_kernel_dims[3] &&
           this->m_kernel_dims[2] == this->m_pads[0] / this->m_dilations[0] * 2 + 1 &&
           this->m_kernel_dims[3] == this->m_pads[1] / this->m_dilations[1] * 2 + 1)) {

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -340,11 +340,10 @@ protected:
     if (this->distconv_enabled()) {
       // REVIEW: distconv-3d
       std::vector<int> overlaps;
-      overlaps.push_back(0); // N
+      for(auto i = this->m_kernel_dims.rbegin(); i != this->m_kernel_dims.rbegin()+dc::num_spatial_dims; ++i)
+        overlaps.push_back((*i - 1) / 2); // W, H, (D)
       overlaps.push_back(0); // C
-      for(auto i = this->m_kernel_dims.begin()+2; i != this->m_kernel_dims.end(); ++i)
-        overlaps.push_back((*i - 1) / 2);
-      std::reverse(overlaps.begin(), overlaps.end());
+      overlaps.push_back(0); // N
       return dc::ArrayND(overlaps);
     } else {
       return dc::ArrayND(0);
@@ -388,7 +387,7 @@ protected:
             [i + 3 * (dc::num_dims - 4)];
         assert(splits != -1);
         if(splits > 1)
-          overlap[dc::num_dims - i] = (this->m_kernel_dims[2 + i] - 1) / 2 * this->m_dilations[i];
+          overlap[dc::num_spatial_dims - 1 - i] = (this->m_kernel_dims[2 + i] - 1) / 2 * this->m_dilations[i];
       }
       auto &prev_activations_dist = dists[this][0];
       prev_activations_dist.set_overlap(overlap);

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -346,7 +346,7 @@ protected:
     if (this->distconv_enabled()) {
       dc::IntVector overlap(dc::num_dims, 0);
       for(int i = 0; i < dc::num_spatial_dims; i++) {
-#ifdef DISTCONV_HAS_DEPTH
+#ifdef LBANN_DISTCONV_HAS_DEPTH
         const int splits = std::vector<int>(
             {this->get_parallel_strategy().depth_splits,
              this->get_parallel_strategy().height_splits,
@@ -355,7 +355,7 @@ protected:
         const int splits = std::vector<int>(
             {this->get_parallel_strategy().height_splits,
              this->get_parallel_strategy().width_splits})[i];
-#endif // DISTCONV_HAS_DEPTH
+#endif // LBANN_DISTCONV_HAS_DEPTH
         if(splits > 1)
           overlap[dc::num_spatial_dims - 1 - i] = (this->m_kernel_dims[2 + i] - 1) / 2 * this->m_dilations[i];
       }

--- a/include/lbann/layers/learning/convolution.hpp
+++ b/include/lbann/layers/learning/convolution.hpp
@@ -344,6 +344,7 @@ protected:
         overlaps.push_back((*i - 1) / 2); // W, H, (D)
       overlaps.push_back(0); // C
       overlaps.push_back(0); // N
+      assert_eq(overlaps.size(), dc::num_dims);
       return dc::ArrayND(overlaps);
     } else {
       return dc::ArrayND(0);
@@ -375,7 +376,7 @@ protected:
         dists, invariants, updated, fixed);
     if (this->distconv_enabled()) {
       // REVIEW: distconv-3d
-          dc::IntVector overlap(dc::num_dims, 0);
+      dc::IntVector overlap(dc::num_dims, 0);
       for(int i = 0; i < dc::num_spatial_dims; i++) {
         const int splits = std::vector<int>(
             {this->get_parallel_strategy().height_splits,
@@ -480,7 +481,6 @@ protected:
     }
   }
 
-  // REVIEW: distconv-3d
   void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     Layer::setup_tensors_bwd(dists);
     if (!this->distconv_enabled()) return;

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -363,7 +363,8 @@ protected:
     assert_eq(m_mean->Matrix().Width() * m_mean->Matrix().Height(),
               num_channels);
 
-    dc::Array4 per_channel_stat_shape = {1, 1, num_channels, 1};
+    // FIXME: distconv-3d
+    dc::ArrayND per_channel_stat_shape = {1, 1, num_channels, 1};
     auto shared_dist = dc::Dist::make_distribution(dists[0].get_locale_shape());
     auto split_shape = dists[0].get_split_shape();
     // set all dimensions to be 1 except for the channel dimension
@@ -409,6 +410,7 @@ protected:
   void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
     Layer::setup_tensors_bwd(dists);
     if (!distconv_enabled()) return;
+    // FIXME: distconv-3d
 
     setup_prev_error_signals_tensor(dists);
     setup_error_signals_tensor(dists);

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -65,7 +65,6 @@ template <data_layout T_layout, El::Device Dev>
 class batch_normalization_layer : public regularizer_layer {
 
 private:
-
   /** Decay rate for the running statistics. */
   DataType m_decay;
   /** Small number to avoid division by zero. */
@@ -345,7 +344,7 @@ protected:
 
   dc::LocaleMPI m_spatial_loc;
 
-  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     Layer::setup_tensors_fwd(dists);
     if (!distconv_enabled()) return;
 
@@ -409,7 +408,7 @@ protected:
         m_var_gradient_t, this->m_var_gradient->Buffer()));
   }
 
-  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     Layer::setup_tensors_bwd(dists);
     if (!distconv_enabled()) return;
 

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -362,7 +362,6 @@ protected:
     assert_eq(m_mean->Matrix().Width() * m_mean->Matrix().Height(),
               num_channels);
 
-    // REVIEW: distconv-3d
     std::vector<int> per_channel_stat_shape_v(dc::num_dims, 1);
     per_channel_stat_shape_v[dc::num_spatial_dims] = num_channels;
     dc::Shape per_channel_stat_shape(per_channel_stat_shape_v);

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -65,6 +65,7 @@ template <data_layout T_layout, El::Device Dev>
 class batch_normalization_layer : public regularizer_layer {
 
 private:
+
   /** Decay rate for the running statistics. */
   DataType m_decay;
   /** Small number to avoid division by zero. */

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -363,9 +363,8 @@ protected:
     assert_eq(m_mean->Matrix().Width() * m_mean->Matrix().Height(),
               num_channels);
 
-    std::vector<int> per_channel_stat_shape_v(dc::num_dims, 1);
-    per_channel_stat_shape_v[dc::num_spatial_dims] = num_channels;
-    dc::Shape per_channel_stat_shape(per_channel_stat_shape_v);
+    dc::Shape per_channel_stat_shape(dc::num_dims, 1);
+    per_channel_stat_shape[dc::num_spatial_dims] = num_channels;
     auto shared_dist = dc::Dist::make_distribution(dists[0].get_locale_shape());
     auto split_shape = dists[0].get_split_shape();
     // set all dimensions to be 1 except for the channel dimension

--- a/include/lbann/layers/regularizers/batch_normalization.hpp
+++ b/include/lbann/layers/regularizers/batch_normalization.hpp
@@ -345,7 +345,7 @@ protected:
 
   dc::LocaleMPI m_spatial_loc;
 
-  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
     Layer::setup_tensors_fwd(dists);
     if (!distconv_enabled()) return;
 
@@ -409,7 +409,7 @@ protected:
         m_var_gradient_t, this->m_var_gradient->Buffer()));
   }
 
-  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
     Layer::setup_tensors_bwd(dists);
     if (!distconv_enabled()) return;
 

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -576,7 +576,7 @@ private:
     if (distconv_enabled()) {
       int stencil_h = (m_pool_dims[0] - 1) / 2;
       int stencil_w = (m_pool_dims[1] - 1) / 2;
-      dc::Array4 overlap(0);
+      dc::IntVector overlap(4, 0);
       if (get_parallel_strategy().width_splits > 1) {
         overlap[0] = stencil_w;
       }

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -573,7 +573,6 @@ private:
       std::set<dc::Dist*> &fixed) override {
     Layer::setup_tensor_distribution_init(
         dists, invariants, updated, fixed);
-    // REVIEW: distconv-3d
     if (distconv_enabled()) {
       dc::IntVector overlap(dc::num_dims, 0);
       for(int i = 0; i < dc::num_spatial_dims; i++) {
@@ -612,7 +611,6 @@ private:
   }
 
   dc::Shape get_activations_tensor_local_shape() const override {
-    // REVIEW: distconv-3d
     const std::vector<int> filter_dims(m_pool_dims.rbegin(), m_pool_dims.rend());
     const std::vector<int> strides(m_strides.rbegin(), m_strides.rend());
     const std::vector<int> dilations(dc::num_spatial_dims, 1);
@@ -628,7 +626,6 @@ private:
     Layer::setup_tensors_fwd(dists);
     if (!distconv_enabled()) return;
 
-    // REVIEW: distconv-3d
     dc::MPIPrintStreamDebug()
         << "pooling: setup_tensors."
         << " pads: " << dc::util::join_xd_array(m_pads)
@@ -696,7 +693,6 @@ private:
   bool using_distconv() const override {
     if (!Layer::using_distconv()) return false;
 
-    // REVIEW: distconv-3d
     bool cond = true;
     for(int i = 0; i < dc::num_spatial_dims; i++)
       cond &= (m_pool_dims[i] % 2 != 0);

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -586,7 +586,6 @@ private:
             {this->get_parallel_strategy().height_splits,
              this->get_parallel_strategy().width_splits})[i];
 #endif // DISTCONV_HAS_DEPTH
-        assert(splits != -1);
         if(splits > 1)
           overlap[dc::num_spatial_dims - 1 - i] = (this->m_pool_dims[i] - 1) / 2;
       }

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -576,7 +576,7 @@ private:
     if (distconv_enabled()) {
       dc::IntVector overlap(dc::num_dims, 0);
       for(int i = 0; i < dc::num_spatial_dims; i++) {
-#ifdef DISTCONV_HAS_DEPTH
+#ifdef LBANN_DISTCONV_HAS_DEPTH
         const int splits = std::vector<int>(
             {this->get_parallel_strategy().depth_splits,
              this->get_parallel_strategy().height_splits,
@@ -585,7 +585,7 @@ private:
         const int splits = std::vector<int>(
             {this->get_parallel_strategy().height_splits,
              this->get_parallel_strategy().width_splits})[i];
-#endif // DISTCONV_HAS_DEPTH
+#endif // LBANN_DISTCONV_HAS_DEPTH
         if(splits > 1)
           overlap[dc::num_spatial_dims - 1 - i] = (this->m_pool_dims[i] - 1) / 2;
       }
@@ -710,7 +710,7 @@ private:
     bool pad_zero = true, pad_stencil = true, stride_one = true, stride_stencil = true;
     for(int i = 0; i < dc::num_spatial_dims; i++) {
       pad_zero &= (m_pads[i] == 0);
-      pad_stencil &= (m_pads[i] == stencils[dc::num_spatial_dims-1-i]);
+      pad_stencil &= (m_pads[i] == stencils[i]);
       stride_one &= (m_strides[i] == 1);
       stride_stencil &= (m_strides[i] == stencils[i] + 1);
     }

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -576,14 +576,16 @@ private:
     if (distconv_enabled()) {
       dc::IntVector overlap(dc::num_dims, 0);
       for(int i = 0; i < dc::num_spatial_dims; i++) {
+#ifdef DISTCONV_HAS_DEPTH
         const int splits = std::vector<int>(
-            {get_parallel_strategy().height_splits,
-             get_parallel_strategy().width_splits,
-             -1,
-             get_parallel_strategy().depth_splits,
-             get_parallel_strategy().height_splits,
-             get_parallel_strategy().width_splits})
-            [i + 3 * (dc::num_dims - 4)];
+            {this->get_parallel_strategy().depth_splits,
+             this->get_parallel_strategy().height_splits,
+             this->get_parallel_strategy().width_splits})[i];
+#else
+        const int splits = std::vector<int>(
+            {this->get_parallel_strategy().height_splits,
+             this->get_parallel_strategy().width_splits})[i];
+#endif // DISTCONV_HAS_DEPTH
         assert(splits != -1);
         if(splits > 1)
           overlap[dc::num_spatial_dims - 1 - i] = (this->m_pool_dims[i] - 1) / 2;

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -587,7 +587,7 @@ private:
             [i + 3 * (dc::num_dims - 4)];
         assert(splits != -1);
         if(splits > 1)
-          overlap[dc::num_dims - i] = (this->m_pool_dims[i] - 1) / 2;
+          overlap[dc::num_spatial_dims - 1 - i] = (this->m_pool_dims[i] - 1) / 2;
       }
       auto &prev_activations_dist = dists[this][0];
       auto &activations_dist = dists[this][1];
@@ -722,7 +722,7 @@ private:
       pad_zero &= (m_pads[i] == 0);
       pad_stencil &= (m_pads[i] == stencils[dc::num_spatial_dims-1-i]);
       stride_one &= (m_strides[i] == 1);
-      stride_stencil &= (m_strides[i] == stencils[dc::num_spatial_dims-1-i] + 1);
+      stride_stencil &= (m_strides[i] == stencils[i] + 1);
     }
 
     if (!(pad_zero || pad_stencil)) {

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -213,6 +213,7 @@ public:
 protected:
 
   void setup_dims() override {
+    // FIXME: distconv-3d
     transform_layer::setup_dims();
     const auto& input_dims = get_input_dims();
     auto output_dims = input_dims;
@@ -573,10 +574,11 @@ private:
       std::set<dc::Dist*> &fixed) override {
     Layer::setup_tensor_distribution_init(
         dists, invariants, updated, fixed);
+    // FIXME: distconv-3d
     if (distconv_enabled()) {
       int stencil_h = (m_pool_dims[0] - 1) / 2;
       int stencil_w = (m_pool_dims[1] - 1) / 2;
-      dc::Array4 overlap(0);
+      dc::ArrayND overlap(0);
       if (get_parallel_strategy().width_splits > 1) {
         overlap[0] = stencil_w;
       }
@@ -604,16 +606,17 @@ private:
           &error_signals_dist);
     }
   }
-  dc::Array4 get_strides() const override {
-    return dc::Array4({m_strides[1], m_strides[0], 1, 1});
+  dc::ArrayND get_strides() const override {
+    return dc::ArrayND({m_strides[1], m_strides[0], 1, 1});
   }
 
-  dc::Array4 get_activations_tensor_local_shape() const override {
+  dc::ArrayND get_activations_tensor_local_shape() const override {
+    // FIXME: distconv-3d
     const std::vector<int> filter_dims = {m_pool_dims[1], m_pool_dims[0]};
     const std::vector<int> strides = {m_strides[1], m_strides[0]};
     const std::vector<int> dilations = {1, 1};
     bool use_padding = m_pads[0] != 0;
-    dc::Array4 output_spatial_local_shape =
+    dc::ArrayND output_spatial_local_shape =
         ::distconv::get_pooling_output_local_tensor_shape(
             m_prev_activations_t,
             filter_dims, strides, use_padding, dilations);
@@ -624,6 +627,7 @@ private:
     Layer::setup_tensors_fwd(dists);
     if (!distconv_enabled()) return;
 
+    // FIXME: distconv-3d
     dc::MPIPrintStreamDebug()
         << "pooling: setup_tensors."
         << " pads: " << m_pads[0] << "x" << m_pads[1]
@@ -691,6 +695,7 @@ private:
   bool using_distconv() const override {
     if (!Layer::using_distconv()) return false;
 
+    // FIXME: distconv-3d
     if (!(m_pool_dims[0] % 2 != 0 && m_pool_dims[1] % 2 != 0)) {
       dc::MPIPrintStreamDebug() << "pooling: unsupported due to window shape: "
                                 << m_pool_dims[0] << "x" << m_pool_dims[1];

--- a/include/lbann/layers/transform/pooling.hpp
+++ b/include/lbann/layers/transform/pooling.hpp
@@ -567,7 +567,7 @@ private:
  public:
 
   void setup_tensor_distribution_init(
-      std::map<const Layer*, std::array<dc::Dist, 4>> &dists,
+      std::map<const Layer*, std::array<dc::Dist, dc::num_dists>> &dists,
       std::map<dc::Dist*, std::set<dc::Dist*>> &invariants,
       std::set<dc::Dist*> &updated,
       std::set<dc::Dist*> &fixed) override {
@@ -631,7 +631,7 @@ private:
     return output_spatial_local_shape;
   }
 
-  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     Layer::setup_tensors_fwd(dists);
     if (!distconv_enabled()) return;
 
@@ -647,7 +647,7 @@ private:
     setup_activations_copyout_tensor(dists);
   }
 
-  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     Layer::setup_tensors_bwd(dists);
     if (!distconv_enabled()) return;
 

--- a/include/lbann/layers/transform/split.hpp
+++ b/include/lbann/layers/transform/split.hpp
@@ -1,5 +1,3 @@
-// REVIEW: distconv-3d
-
 ////////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory.

--- a/include/lbann/layers/transform/split.hpp
+++ b/include/lbann/layers/transform/split.hpp
@@ -91,7 +91,7 @@ protected:
   void fp_compute_distconv() {}
 
  public:
-  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
     Layer::setup_tensors_fwd(dists);
     if (!this->distconv_enabled()) return;
     this->setup_prev_activations_tensor(dists);
@@ -100,7 +100,7 @@ protected:
     this->setup_activations_copyout_tensor(dists);
   }
 
-  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
     Layer::setup_tensors_bwd(dists);
     if (!this->distconv_enabled()) return;
 

--- a/include/lbann/layers/transform/split.hpp
+++ b/include/lbann/layers/transform/split.hpp
@@ -91,7 +91,7 @@ protected:
   void fp_compute_distconv() {}
 
  public:
-  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     Layer::setup_tensors_fwd(dists);
     if (!this->distconv_enabled()) return;
     this->setup_prev_activations_tensor(dists);
@@ -100,7 +100,7 @@ protected:
     this->setup_activations_copyout_tensor(dists);
   }
 
-  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     Layer::setup_tensors_bwd(dists);
     if (!this->distconv_enabled()) return;
 

--- a/include/lbann/layers/transform/split.hpp
+++ b/include/lbann/layers/transform/split.hpp
@@ -1,3 +1,5 @@
+// REVIEW: distconv-3d
+
 ////////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory.
@@ -89,7 +91,7 @@ protected:
   void fp_compute_distconv() {}
 
  public:
-  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
     Layer::setup_tensors_fwd(dists);
     if (!this->distconv_enabled()) return;
     this->setup_prev_activations_tensor(dists);
@@ -98,7 +100,7 @@ protected:
     this->setup_activations_copyout_tensor(dists);
   }
 
-  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
     Layer::setup_tensors_bwd(dists);
     if (!this->distconv_enabled()) return;
 

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -1,5 +1,3 @@
-// REVIEW: distconv-3d
-
 ////////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory.

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -113,7 +113,7 @@ protected:
   std::vector<dc::TensorDev> m_prev_activations_siblings;
 
  public:
-  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     Layer::setup_tensors_fwd(dists);
     if (!this->distconv_enabled()) return;
     this->setup_prev_activations_tensor(dists);
@@ -129,7 +129,7 @@ protected:
     }
   }
 
-  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     Layer::setup_tensors_bwd(dists);
     if (!this->distconv_enabled()) return;
 

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -113,7 +113,7 @@ protected:
   std::vector<dc::TensorDev> m_prev_activations_siblings;
 
  public:
-  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
     Layer::setup_tensors_fwd(dists);
     if (!this->distconv_enabled()) return;
     this->setup_prev_activations_tensor(dists);
@@ -129,7 +129,7 @@ protected:
     }
   }
 
-  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
     Layer::setup_tensors_bwd(dists);
     if (!this->distconv_enabled()) return;
 

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -1,3 +1,5 @@
+// REVIEW: distconv-3d
+
 ////////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2014-2016, Lawrence Livermore National Security, LLC.
 // Produced at the Lawrence Livermore National Laboratory.
@@ -111,7 +113,7 @@ protected:
   std::vector<dc::TensorDev> m_prev_activations_siblings;
 
  public:
-  void setup_tensors_fwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
     Layer::setup_tensors_fwd(dists);
     if (!this->distconv_enabled()) return;
     this->setup_prev_activations_tensor(dists);
@@ -127,7 +129,7 @@ protected:
     }
   }
 
-  void setup_tensors_bwd(const std::array<dc::Dist, 4> &dists) override {
+  void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dims> &dists) override {
     Layer::setup_tensors_bwd(dists);
     if (!this->distconv_enabled()) return;
 

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -61,6 +61,10 @@ namespace dc {
 // Helper type aliases
 ////////////////////////////////////////////////////////////
 using Array4 = ::distconv::tensor::Array<4>;
+template <typename DataType>
+using Vector = ::distconv::Vector<DataType>;
+using IntVector = ::distconv::IntVector;
+using Shape = ::distconv::tensor::Shape;
 
 using TensorHost = ::distconv::tensor::Tensor<
   4, DataType, ::distconv::tensor::LocaleMPI,
@@ -79,7 +83,7 @@ using TensorShufflerAL = ::distconv::tensor::TensorMPICUDAShufflerAL<
 using TensorShufflerHybrid = ::distconv::tensor::TensorMPICUDAShufflerHybrid<
   4, DataType>;
 
-using Dist = ::distconv::tensor::Distribution<4>;
+using Dist = ::distconv::tensor::Distribution;
 
 using LocaleMPI = ::distconv::tensor::LocaleMPI;
 

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -88,6 +88,7 @@ using TensorShufflerHybrid = ::distconv::tensor::TensorMPICUDAShufflerHybrid<
   num_dims, DataType>;
 
 using Dist = ::distconv::tensor::Distribution;
+static constexpr int num_dists = 4;
 
 using LocaleMPI = ::distconv::tensor::LocaleMPI;
 

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -57,29 +57,31 @@
 namespace lbann {
 namespace dc {
 
+static constexpr num_dims = 4; // TODO: set 4 or 5 via DISTCONV_NUM_DIMS
+
 ////////////////////////////////////////////////////////////
 // Helper type aliases
 ////////////////////////////////////////////////////////////
-using Array4 = ::distconv::tensor::Array<4>;
+using ArrayND = ::distconv::tensor::Array<num_dims>;
 
 using TensorHost = ::distconv::tensor::Tensor<
-  4, DataType, ::distconv::tensor::LocaleMPI,
+  num_dims, DataType, ::distconv::tensor::LocaleMPI,
   ::distconv::tensor::CUDAAllocator>;
 
 using TensorDev = ::distconv::tensor::Tensor<
-  4, DataType, ::distconv::tensor::LocaleMPI,
+  num_dims, DataType, ::distconv::tensor::LocaleMPI,
   ::distconv::tensor::CUDAAllocator>;
 
 using TensorShuffler = ::distconv::tensor::TensorMPICUDAShuffler<
-  4, DataType>;
+  num_dims, DataType>;
 using TensorShufflerP2P = ::distconv::tensor::TensorMPICUDAShufflerP2P<
-  4, DataType>;
+  num_dims, DataType>;
 using TensorShufflerAL = ::distconv::tensor::TensorMPICUDAShufflerAL<
-  4, DataType>;
+  num_dims, DataType>;
 using TensorShufflerHybrid = ::distconv::tensor::TensorMPICUDAShufflerHybrid<
-  4, DataType>;
+  num_dims, DataType>;
 
-using Dist = ::distconv::tensor::Distribution<4>;
+using Dist = ::distconv::tensor::Distribution<num_dims>;
 
 using LocaleMPI = ::distconv::tensor::LocaleMPI;
 
@@ -92,8 +94,8 @@ using MPIRootPrintStreamInfo = ::distconv::util::MPIRootPrintStreamInfo;
 
 using Backend = ::distconv::cudnn::BackendCUDNN;
 using ReLU = ::distconv::ReLU<Backend>;
-using Convolution = ::distconv::Convolution<Backend, 4, DataType>;
-using Pooling = ::distconv::Pooling<Backend, 4, DataType>;
+using Convolution = ::distconv::Convolution<Backend, num_dims, DataType>;
+using Pooling = ::distconv::Pooling<Backend, num_dims, DataType>;
 using BatchNormalization = ::distconv::BatchNormalization<Backend, DataType>;
 
 namespace tensor = ::distconv::tensor;

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -58,7 +58,7 @@
 namespace lbann {
 namespace dc {
 
-static constexpr int num_dims = 4; // TODO: set 4 or 5 via DISTCONV_NUM_DIMS
+static constexpr int num_dims = 4; // TODO: distconv-3d, set 4 or 5 via DISTCONV_NUM_DIMS
 static constexpr int num_spatial_dims = num_dims - 2;
 
 ////////////////////////////////////////////////////////////

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -42,6 +42,9 @@
 
 #if LBANN_DISTCONV_NUM_DIMS == 5
 #define DISTCONV_HAS_DEPTH
+#elif LBANN_DISTCONV_NUM_DIMS == 4
+#else
+#error Only 4 or 5 are supported for LBANN_DISTCONV_NUM_DIMS.
 #endif
 
 //#define DISTCONV_ZERO_OUT_ERROR_SIGNALS

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -40,6 +40,10 @@
 
 #define DISTCONV_HAS_CUDNN
 
+#if LBANN_DISTCONV_NUM_DIMS == 5
+#define DISTCONV_HAS_DEPTH
+#endif
+
 //#define DISTCONV_ZERO_OUT_ERROR_SIGNALS
 // temporary workaround
 #define DISTCONV_USE_SAME_RELU_CALL_AS_LBANN

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -52,12 +52,14 @@
 #include "distconv/tensor/shuffle_al.hpp"
 #include "distconv/tensor/shuffle_hybrid.hpp"
 #include "distconv/tensor/algorithms.hpp"
+#include "distconv/util/util.hpp"
 #include "p2p/p2p.hpp"
 
 namespace lbann {
 namespace dc {
 
-static constexpr num_dims = 4; // TODO: set 4 or 5 via DISTCONV_NUM_DIMS
+static constexpr int num_dims = 4; // TODO: set 4 or 5 via DISTCONV_NUM_DIMS
+static constexpr int num_spatial_dims = num_dims - 2;
 
 ////////////////////////////////////////////////////////////
 // Helper type aliases

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -58,7 +58,7 @@
 namespace lbann {
 namespace dc {
 
-static constexpr int num_dims = 4; // TODO: distconv-3d, set 4 or 5 via DISTCONV_NUM_DIMS
+static constexpr int num_dims = LBANN_DISTCONV_NUM_DIMS;
 static constexpr int num_spatial_dims = num_dims - 2;
 
 ////////////////////////////////////////////////////////////

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -40,13 +40,6 @@
 
 #define DISTCONV_HAS_CUDNN
 
-#if LBANN_DISTCONV_NUM_DIMS == 5
-#define DISTCONV_HAS_DEPTH
-#elif LBANN_DISTCONV_NUM_DIMS == 4
-#else
-#error Only 4 or 5 are supported for LBANN_DISTCONV_NUM_DIMS.
-#endif
-
 //#define DISTCONV_ZERO_OUT_ERROR_SIGNALS
 // temporary workaround
 #define DISTCONV_USE_SAME_RELU_CALL_AS_LBANN

--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -74,6 +74,7 @@ WITH_CONDUIT=OFF
 WITH_DISTCONV=OFF
 DISTCONV_URL=ssh://git@cz-bitbucket.llnl.gov:7999/~maruyama/distconv.git
 DISTCONV_TAG=master
+LBANN_DISTCONV_NUM_DIMS=4
 WITH_TBINF=OFF
 RECONFIGURE=0
 USE_NINJA=0
@@ -287,6 +288,10 @@ while :; do
 			DISTCONV_TAG=$2
 			shift
 			;;
+		--distconv-num-dims)
+			LBANN_DISTCONV_NUM_DIMS=$2
+			shift
+			;;
         --instrument)
             INSTRUMENT="-finstrument-functions -ldl"
             ;;
@@ -338,7 +343,7 @@ if [ ${USE_MODULES} -ne 0 ]; then
         HDF5_CMAKE_EXE=$(which cmake)
     fi
     module load cmake/3.9.2
-    
+
     CMAKE_PATH=$(dirname $(which cmake))
 else
     use git
@@ -842,6 +847,7 @@ CONFIGURE_COMMAND=$(cat << EOF
 -D LBANN_WITH_DISTCONV=${WITH_DISTCONV} \
 -D DISTCONV_URL=${DISTCONV_URL} \
 -D DISTCONV_TAG=${DISTCONV_TAG} \
+-D LBANN_DISTCONV_NUM_DIMS=${LBANN_DISTCONV_NUM_DIMS} \
 -D LBANN_SB_BUILD_P2P=${WITH_DISTCONV} \
 -D LBANN_WITH_P2P=${WITH_DISTCONV} \
 -D LBANN_SB_FWD_HYDROGEN_Hydrogen_AVOID_CUDA_AWARE_MPI=${AVOID_CUDA_AWARE_MPI} \

--- a/scripts/proto/lbann/modules.py
+++ b/scripts/proto/lbann/modules.py
@@ -61,7 +61,7 @@ class FullyConnectedModule(Module):
     global_count = 0  # Static counter, used for default names
 
     def __init__(self, size, bias=True, weights=[], activation=None,
-                 name=None, data_layout='data_parallel'):
+                 name=None, data_layout='data_parallel', parallel_strategy={}):
         """Initialize fully-connected module.
 
         Args:
@@ -85,6 +85,7 @@ class FullyConnectedModule(Module):
                      if name
                      else 'fcmodule{0}'.format(FullyConnectedModule.global_count))
         self.data_layout = data_layout
+        self.parallel_strategy = parallel_strategy
 
         # Initialize weights
         # Note: If weights are not provided, matrix weights are
@@ -122,11 +123,13 @@ class FullyConnectedModule(Module):
                               name=(name+'_fc' if self.activation else name),
                               data_layout=self.data_layout,
                               num_neurons=self.size,
-                              has_bias=self.bias)
+                              has_bias=self.bias,
+                              parallel_strategy=self.parallel_strategy)
         if self.activation:
             return self.activation(y,
                                    name=name+'_activation',
-                                   data_layout=self.data_layout)
+                                   data_layout=self.data_layout,
+                                   parallel_strategy=self.parallel_strategy)
         else:
             return y
 
@@ -142,7 +145,7 @@ class ConvolutionNdModule(Module):
     def __init__(self, num_dims,
                  out_channels, kernel_size,
                  stride=1, padding=0, dilation=1, groups=1, bias=True,
-                 weights=[], activation=None, name=None):
+                 weights=[], activation=None, name=None, parallel_strategy={}):
         """Initialize convolution module.
 
         Args:
@@ -178,6 +181,7 @@ class ConvolutionNdModule(Module):
         self.name = (name
                      if name
                      else 'convmodule{0}'.format(ConvolutionNdModule.global_count))
+        self.parallel_strategy = parallel_strategy
 
         # Initialize weights
         # Note: If weights are not provided, kernel weights are
@@ -221,9 +225,11 @@ class ConvolutionNdModule(Module):
                            conv_strides_i=self.stride,
                            conv_dilations_i=self.dilation,
                            num_groups=self.groups,
-                           has_bias=self.bias)
+                           has_bias=self.bias,
+                           parallel_strategy=self.parallel_strategy)
         if self.activation:
-            return self.activation(y, name=name+'_activation')
+            return self.activation(y, name=name+'_activation',
+                                   parallel_strategy=self.parallel_strategy)
         else:
             return y
 

--- a/src/layers/activations/relu.cpp
+++ b/src/layers/activations/relu.cpp
@@ -81,7 +81,7 @@ using namespace dc;
 
 template <>
 void relu_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::setup_tensor_distribution_init(
-    std::map<const Layer*, std::array<Dist, 4>> &dists,
+    std::map<const Layer*, std::array<Dist, dc::num_dists>> &dists,
     std::map<Dist*, std::set<Dist*>> &invariants,
     std::set<Dist*> &updated,
     std::set<Dist*> &fixed)  {
@@ -112,7 +112,7 @@ void relu_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::setup_tensor_distr
 
 template <>
 void relu_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::
-setup_tensors_fwd(const std::array<Dist, 4> &dists) {
+setup_tensors_fwd(const std::array<Dist, dc::num_dists> &dists) {
   Layer::setup_tensors_fwd(dists);
   if (!distconv_enabled()) return;
   setup_prev_activations_tensor(dists);
@@ -122,7 +122,7 @@ setup_tensors_fwd(const std::array<Dist, 4> &dists) {
 
 template <>
 void relu_layer<data_layout::DATA_PARALLEL, El::Device::GPU>::
-setup_tensors_bwd(const std::array<Dist, 4> &dists)  {
+setup_tensors_bwd(const std::array<Dist, dc::num_dists> &dists)  {
   Layer::setup_tensors_bwd(dists);
   if (!distconv_enabled()) return;
   setup_prev_error_signals_tensor(dists);

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1463,13 +1463,13 @@ void Layer::setup_tensor_distribution_init(
   if (ps.height_splits == 0) ps.height_splits = h;
   if (ps.width_splits == 0) ps.width_splits = w;
 
-  Array4 input_locale_shape({w, h, c, n});
-  Array4 input_split_shape({ps.width_splits, ps.height_splits,
+  Shape input_locale_shape({w, h, c, n});
+  Shape input_split_shape({ps.width_splits, ps.height_splits,
           ps.channel_splits, ps.sample_splits});
   auto prev_activations_dist =  Dist::make_shared_distribution(
       input_locale_shape, input_split_shape);
-  Array4 output_locale_shape({w, h, f, n});
-  Array4 output_split_shape({ps.width_splits, ps.height_splits,
+  Shape output_locale_shape({w, h, f, n});
+  Shape output_split_shape({ps.width_splits, ps.height_splits,
           ps.filter_splits, ps.sample_splits});
   auto activations_dist = Dist::make_shared_distribution(
       output_locale_shape, output_split_shape);
@@ -1538,12 +1538,10 @@ Dist get_hydrogen_matrix_distribution() {
   // dimension. It is assumed that LBANN uses only the
   // NUM_RANKS/STRIDE ranks in a data-parallel input layer to read
   // training data.
-  Array4 sample_locale_shape =
-      {static_cast<index_t>(dc::get_rank_stride()),
-       index_t(1), index_t(1),
-       static_cast<index_t>(
-           dc::get_mpi_num_ranks() / dc::get_rank_stride())};
-  Array4 sample_split_shape = sample_locale_shape;
+  Shape sample_locale_shape({static_cast<index_t>(dc::get_rank_stride()),
+          index_t(1), index_t(1), static_cast<index_t>(
+              dc::get_mpi_num_ranks() / dc::get_rank_stride())});
+  auto sample_split_shape = sample_locale_shape;
   sample_split_shape[0] = 1;
   auto sample_dist = Dist::make_shared_distribution
       (sample_locale_shape, sample_split_shape);
@@ -1559,14 +1557,14 @@ size_t Layer::estimate_memory_usage(const std::array<Dist, 4> &dists) {
   size_t usage = 0;
   // fp
   if (m_parent_copy_in_required || m_parent_shuffle_required) {
-    usage += get_input_size() * max_mb / dists[0].get_split_shape().get_size();
+    usage += get_input_size() * max_mb / dists[0].get_split_shape().size();
   }
-  usage += get_output_size() * max_mb / dists[1].get_split_shape().get_size();
+  usage += get_output_size() * max_mb / dists[1].get_split_shape().size();
   // bp
   if (m_child_copy_out_required || m_child_shuffle_required) {
-    usage += get_output_size() * max_mb / dists[3].get_split_shape().get_size();
+    usage += get_output_size() * max_mb / dists[3].get_split_shape().size();
   }
-  usage += get_input_size() * max_mb / dists[2].get_split_shape().get_size();
+  usage += get_input_size() * max_mb / dists[2].get_split_shape().size();
   return usage * sizeof(DataType);
 }
 void Layer::setup_prev_activations_tensor(const std::array<Dist, 4> &dists) {

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1562,7 +1562,7 @@ Dist get_hydrogen_matrix_distribution() {
   // NUM_RANKS/STRIDE ranks in a data-parallel input layer to read
   // training data.
 
-  std::vector<index_t> sample_locale_shape_v(index_t(1), dc::num_dims);
+  std::vector<index_t> sample_locale_shape_v(dc::num_dims, index_t(1));
   sample_locale_shape_v[0] = static_cast<index_t>(dc::get_rank_stride());
   sample_locale_shape_v[dc::num_spatial_dims+1] = static_cast<index_t>(dc::get_mpi_num_ranks() / dc::get_rank_stride());
   Shape sample_locale_shape(sample_locale_shape_v);

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1416,7 +1416,7 @@ void Layer::setup_tensor_distribution_init(
   int w = ps.width_groups;
   int np = m_comm->get_procs_per_trainer();
 
-  if(dc::num_dims == 4 && d != 1) {
+  if(dc::num_dims == 4 && d > 1) {
     MPIRootPrintStreamError() << "The numbers of depth decomposition should be 1.\n";
     throw lbann_exception();
   }

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1416,9 +1416,12 @@ void Layer::setup_tensor_distribution_init(
   int w = ps.width_groups;
   int np = m_comm->get_procs_per_trainer();
 
-  if(dc::num_dims == 4 && d > 1) {
-    MPIRootPrintStreamError() << "The numbers of depth decomposition should be 1.\n";
-    throw lbann_exception();
+  if(dc::num_dims == 4) {
+    if(d > 1) {
+      MPIRootPrintStreamError() << "The numbers of depth decomposition should be 1.\n";
+      throw lbann_exception();
+    }
+    d = 1;
   }
 
   // if only one process is used, do not parallelize

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1400,7 +1400,7 @@ void Layer::setup_keep_original_tensors() {
 }
 
 void Layer::setup_tensor_distribution_init(
-    std::map<const Layer*, std::array<dc::Dist, dc::num_dims>> &dists,
+    std::map<const Layer*, std::array<dc::Dist, 4>> &dists,
     std::map<dc::Dist*, std::set<dc::Dist*>> &invariants,
     std::set<dc::Dist*> &updated,
     std::set<dc::Dist*> &fixed) {
@@ -1508,7 +1508,7 @@ void Layer::setup_tensor_distribution_init(
       output_locale_shape, output_split_shape);
   auto prev_error_signals_dist = activations_dist;
   auto error_signals_dist = prev_activations_dist;
-  std::array<Dist, dc::num_dims> layer_dists = {prev_activations_dist,
+  std::array<Dist, 4> layer_dists = {prev_activations_dist,
                                                 activations_dist,
                                                 error_signals_dist,
                                                 prev_error_signals_dist};
@@ -1520,7 +1520,7 @@ void Layer::setup_tensor_distribution_init(
 }
 
 void Layer::setup_tensor_distribution_add_adjacent_invariants(
-    std::map<const Layer*, std::array<Dist, dc::num_dims>> &dists,
+    std::map<const Layer*, std::array<Dist, 4>> &dists,
     std::map<Dist*, std::set<Dist*>> &invariants) {
   if (!distconv_enabled()) return;
   auto &layer_dists = dists[this];
@@ -1584,7 +1584,7 @@ Dist get_hydrogen_matrix_distribution() {
 }
 } // namespace
 
-size_t Layer::estimate_memory_usage(const std::array<Dist, dc::num_dims> &dists) {
+size_t Layer::estimate_memory_usage(const std::array<Dist, 4> &dists) {
   if (!distconv_enabled()) {
     return 0;
   }
@@ -1602,7 +1602,7 @@ size_t Layer::estimate_memory_usage(const std::array<Dist, dc::num_dims> &dists)
   usage += get_input_size() * max_mb / dists[2].get_split_shape().get_size();
   return usage * sizeof(DataType);
 }
-void Layer::setup_prev_activations_tensor(const std::array<Dist, dc::num_dims> &dists) {
+void Layer::setup_prev_activations_tensor(const std::array<Dist, 4> &dists) {
   // REVIEW: distconv-3d
   const ArrayND input_tensor_shape = get_input_tensor_shape();
   const LocaleMPI loc(dc::get_mpi_comm(), false);
@@ -1650,7 +1650,7 @@ ArrayND Layer::get_activations_tensor_local_shape() const {
   return m_prev_activations_t.get_local_shape();
 }
 
-void Layer::setup_activations_tensor(const std::array<Dist, dc::num_dims> &dists,
+void Layer::setup_activations_tensor(const std::array<Dist, 4> &dists,
                                      bool allocate) {
   // REVIEW: distconv-3d
   const LocaleMPI loc(dc::get_mpi_comm(), false);
@@ -1666,7 +1666,7 @@ void Layer::setup_activations_tensor(const std::array<Dist, dc::num_dims> &dists
   }
 }
 
-void Layer::setup_activations_copyout_tensor(const std::array<Dist, dc::num_dims> &dists) {
+void Layer::setup_activations_copyout_tensor(const std::array<Dist, 4> &dists) {
   // REVIEW: distconv-3d
   const LocaleMPI loc(dc::get_mpi_comm(), false);
   const ArrayND sample_block_size = get_sample_block_size();
@@ -1689,11 +1689,11 @@ void Layer::setup_activations_copyout_tensor(const std::array<Dist, dc::num_dims
 }
 
 // REVIEW: distconv-3d
-void Layer::setup_tensors_bwd(const std::array<Dist, dc::num_dims> &dists) {}
+void Layer::setup_tensors_bwd(const std::array<Dist, 4> &dists) {}
 
 void Layer::setup_distconv_post(size_t) {}
 
-void Layer::setup_prev_error_signals_tensor(const std::array<Dist, dc::num_dims> &dists) {
+void Layer::setup_prev_error_signals_tensor(const std::array<Dist, 4> &dists) {
   // REVIEW: distconv-3d
   const LocaleMPI loc(dc::get_mpi_comm(), false);
   const ArrayND sample_block_size = get_sample_block_size();
@@ -1736,7 +1736,7 @@ void Layer::setup_prev_error_signals_tensor(const std::array<Dist, dc::num_dims>
 }
 
 // REVIEW: distconv-3d
-void Layer::setup_error_signals_tensor(const std::array<Dist, dc::num_dims> &dists) {
+void Layer::setup_error_signals_tensor(const std::array<Dist, 4> &dists) {
   const ArrayND input_tensor_shape = get_input_tensor_shape();
   const LocaleMPI loc(dc::get_mpi_comm(), false);
   m_error_signals_t = TensorDev(input_tensor_shape, loc,
@@ -1750,7 +1750,7 @@ void Layer::setup_error_signals_tensor(const std::array<Dist, dc::num_dims> &dis
 }
 
 // REVIEW: distconv-3d
-void Layer::setup_error_signals_copyout_tensor(const std::array<Dist, dc::num_dims> &dists) {
+void Layer::setup_error_signals_copyout_tensor(const std::array<Dist, 4> &dists) {
   const ArrayND input_tensor_shape = get_input_tensor_shape();
   const LocaleMPI loc(dc::get_mpi_comm(), false);
   const Dist sample_dist = get_hydrogen_matrix_distribution();

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1561,9 +1561,11 @@ Dist get_hydrogen_matrix_distribution() {
   // dimension. It is assumed that LBANN uses only the
   // NUM_RANKS/STRIDE ranks in a data-parallel input layer to read
   // training data.
-  Shape sample_locale_shape({static_cast<index_t>(dc::get_rank_stride()),
-          index_t(1), index_t(1), index_t(1), static_cast<index_t>(
-              dc::get_mpi_num_ranks() / dc::get_rank_stride())});
+
+  std::vector<index_t> sample_locale_shape_v(index_t(1), dc::num_dims);
+  sample_locale_shape_v[0] = static_cast<index_t>(dc::get_rank_stride());
+  sample_locale_shape_v[dc::num_spatial_dims+1] = static_cast<index_t>(dc::get_mpi_num_ranks() / dc::get_rank_stride());
+  Shape sample_locale_shape(sample_locale_shape_v);
   auto sample_split_shape = sample_locale_shape;
   sample_split_shape[0] = 1;
   auto sample_dist = Dist::make_shared_distribution

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1497,7 +1497,7 @@ void Layer::setup_tensor_distribution_init(
     input_locale_shape = {w, h, d, c, n};
     input_split_shape = {ps.width_splits, ps.height_splits, ps.depth_splits,
                          ps.channel_splits, ps.sample_splits};
-    output_locale_shape = {w, h, f, n};
+    output_locale_shape = {w, h, d, f, n};
     output_split_shape = {ps.width_splits, ps.height_splits, ps.depth_splits,
                           ps.filter_splits, ps.sample_splits};
   }

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1347,12 +1347,12 @@ void Layer::setup_inter_layer_adaptation() {
   const auto &child_layers = get_child_layers();
   MPIPrintStreamDebug() << ": number of children: "
                             << child_layers.size()
-                            << ", child name: " << child_layers[0]->get_name()
+                            << ", child name: " << (child_layers.size() > 0 ? child_layers[0]->get_name() : "not available")
                             << "\n";
   const auto &parent_layers = get_parent_layers();
   MPIPrintStreamDebug() << ": number of parents: "
                             << parent_layers.size()
-                            << ", parent name: " << parent_layers[0]->get_name()
+                            << ", parent name: " << (parent_layers.size() > 0 ? parent_layers[0]->get_name() : "not available")
                             << "\n";
 
   const auto &ps = get_parallel_strategy();

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1573,7 +1573,7 @@ Dist get_hydrogen_matrix_distribution() {
   // NUM_RANKS/STRIDE ranks in a data-parallel input layer to read
   // training data.
   Shape sample_locale_shape({static_cast<index_t>(dc::get_rank_stride()),
-          index_t(1), index_t(1), static_cast<index_t>(
+          index_t(1), index_t(1), index_t(1), static_cast<index_t>(
               dc::get_mpi_num_ranks() / dc::get_rank_stride())});
   auto sample_split_shape = sample_locale_shape;
   sample_split_shape[0] = 1;
@@ -1609,13 +1609,12 @@ void Layer::setup_prev_activations_tensor(const std::array<Dist, dc::num_dists> 
   const Dist sample_dist = get_hydrogen_matrix_distribution();
   ArrayND input_local_shape = input_tensor_shape;
   // Assuming single GPU per rank
-  //input_local_shape[3] = m_max_mini_batch_size_per_gpu;
+  //input_local_shape[-1] = m_max_mini_batch_size_per_gpu;
   // m_max_mini_batch_size_per_gpu is the maximum among all GPUs, so
   // it's larger than the actual maximum size for some ranks when the
   // mini batch size is not divisible.
-  input_local_shape[dc::num_spatial_dims+1] = 0;
+  input_local_shape[-1] = 0;
   const ArrayND spatial_local_size(std::vector<int>(dc::num_dims, 0));
-
   if (m_parent_copy_in_required || m_parent_shuffle_required) {
     if (m_parent_copy_in_required) {
       m_prev_activations_const_view = TensorDev(input_tensor_shape, loc,
@@ -1672,8 +1671,8 @@ void Layer::setup_activations_copyout_tensor(const std::array<Dist, dc::num_dist
   const Dist sample_dist = get_hydrogen_matrix_distribution();
   const ArrayND output_tensor_shape = get_output_tensor_shape();
   ArrayND output_local_shape = output_tensor_shape;
-  //output_local_shape[dc::num_spatial_dims+1] = m_max_mini_batch_size_per_gpu;
-  output_local_shape[dc::num_spatial_dims+1] = 0;
+  //output_local_shape[-1] = m_max_mini_batch_size_per_gpu;
+  output_local_shape[-1] = 0;
   m_activations_copyout = TensorDev(output_tensor_shape, loc, sample_dist,
                                     output_local_shape, sample_block_size);
   if (m_child_copy_out_required) {
@@ -1699,8 +1698,8 @@ void Layer::setup_prev_error_signals_tensor(const std::array<Dist, dc::num_dists
   const Dist sample_dist = get_hydrogen_matrix_distribution();
   const ArrayND output_tensor_shape = get_output_tensor_shape();
   ArrayND output_local_shape = output_tensor_shape;
-  //output_local_shape[dc::num_spatial_dims+1] = m_max_mini_batch_size_per_gpu;
-  output_local_shape[dc::num_spatial_dims+1] = 0;
+  //output_local_shape[-1] = m_max_mini_batch_size_per_gpu;
+  output_local_shape[-1] = 0;
 
   if (m_child_copy_out_required || m_child_shuffle_required) {
     if (m_child_copy_out_required) {
@@ -1755,8 +1754,8 @@ void Layer::setup_error_signals_copyout_tensor(const std::array<Dist, dc::num_di
   const Dist sample_dist = get_hydrogen_matrix_distribution();
   ArrayND input_local_shape = input_tensor_shape;
   // Assuming single GPU per rank
-  //input_local_shape[3] = m_max_mini_batch_size_per_gpu;
-  input_local_shape[3] = 0;
+  //input_local_shape[-1] = m_max_mini_batch_size_per_gpu;
+  input_local_shape[-1] = 0;
   const ArrayND sample_block_size = get_sample_block_size();
 
   m_error_signals_copyout = TensorDev(input_tensor_shape, loc, sample_dist,

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1487,19 +1487,19 @@ void Layer::setup_tensor_distribution_init(
   Shape output_split_shape;
 
   if(dc::num_dims == 4) {
-    input_locale_shape = {w, h, c, n};
-    input_split_shape = {ps.width_splits, ps.height_splits,
-                         ps.channel_splits, ps.sample_splits};
-    output_locale_shape = {w, h, f, n};
-    output_split_shape = {ps.width_splits, ps.height_splits,
-                          ps.filter_splits, ps.sample_splits};
+    input_locale_shape = Shape({w, h, c, n});
+    input_split_shape = Shape({ps.width_splits, ps.height_splits,
+                               ps.channel_splits, ps.sample_splits});
+    output_locale_shape = Shape({w, h, f, n});
+    output_split_shape = Shape({ps.width_splits, ps.height_splits,
+                                ps.filter_splits, ps.sample_splits});
   } else {
-    input_locale_shape = {w, h, d, c, n};
-    input_split_shape = {ps.width_splits, ps.height_splits, ps.depth_splits,
-                         ps.channel_splits, ps.sample_splits};
-    output_locale_shape = {w, h, f, n};
-    output_split_shape = {ps.width_splits, ps.height_splits, ps.depth_splits,
-                          ps.filter_splits, ps.sample_splits};
+    input_locale_shape = Shape({w, h, d, c, n});
+    input_split_shape = Shape({ps.width_splits, ps.height_splits, ps.depth_splits,
+                               ps.channel_splits, ps.sample_splits});
+    output_locale_shape = Shape({w, h, f, n});
+    output_split_shape = Shape({ps.width_splits, ps.height_splits, ps.depth_splits,
+                                ps.filter_splits, ps.sample_splits});
   }
 
   auto prev_activations_dist =  Dist::make_shared_distribution(

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1407,7 +1407,6 @@ void Layer::setup_tensor_distribution_init(
   auto &ps = get_parallel_strategy();
   MPIRootPrintStreamInfo() << "Parallel Strategy for layer " << get_name()
                            << ": " << ps << "\n";
-  // REVIEW: distconv-3d
   int n = ps.sample_groups;
   int c = ps.channel_groups;
   int f = ps.filter_groups;
@@ -1586,7 +1585,6 @@ size_t Layer::estimate_memory_usage(const std::array<Dist, dc::num_dists> &dists
 }
 
 void Layer::setup_prev_activations_tensor(const std::array<Dist, dc::num_dists> &dists) {
-  // REVIEW: distconv-3d
   const auto input_tensor_shape = get_input_tensor_shape();
   const LocaleMPI loc(dc::get_mpi_comm(), false);
   const auto sample_block_size = get_sample_block_size();
@@ -1627,7 +1625,6 @@ Shape Layer::get_activations_tensor_local_shape() const {
 
 void Layer::setup_activations_tensor(const std::array<Dist, dc::num_dists> &dists,
                                      bool allocate) {
-  // REVIEW: distconv-3d
   const LocaleMPI loc(dc::get_mpi_comm(), false);
   const Shape output_tensor_shape = get_output_tensor_shape();
   const auto activations_local_shape =
@@ -1641,7 +1638,6 @@ void Layer::setup_activations_tensor(const std::array<Dist, dc::num_dists> &dist
 }
 
 void Layer::setup_activations_copyout_tensor(const std::array<Dist, dc::num_dists> &dists) {
-  // REVIEW: distconv-3d
   const LocaleMPI loc(dc::get_mpi_comm(), false);
   const Dist sample_dist = get_hydrogen_matrix_distribution();
   const Shape output_tensor_shape = get_output_tensor_shape();
@@ -1662,13 +1658,11 @@ void Layer::setup_activations_copyout_tensor(const std::array<Dist, dc::num_dist
                         << "activations: " << m_activations_t;
 }
 
-// REVIEW: distconv-3d
 void Layer::setup_tensors_bwd(const std::array<Dist, dc::num_dists> &dists) {}
 
 void Layer::setup_distconv_post(size_t) {}
 
 void Layer::setup_prev_error_signals_tensor(const std::array<Dist, dc::num_dists> &dists) {
-  // REVIEW: distconv-3d
   const LocaleMPI loc(dc::get_mpi_comm(), false);
   const Dist sample_dist = get_hydrogen_matrix_distribution();
   const Shape output_tensor_shape = get_output_tensor_shape();
@@ -1705,7 +1699,6 @@ void Layer::setup_prev_error_signals_tensor(const std::array<Dist, dc::num_dists
                         << "prev error signals: " << m_prev_error_signals_t;
 }
 
-// REVIEW: distconv-3d
 void Layer::setup_error_signals_tensor(const std::array<Dist, dc::num_dists> &dists) {
   const Shape input_tensor_shape = get_input_tensor_shape();
   const LocaleMPI loc(dc::get_mpi_comm(), false);
@@ -1718,7 +1711,6 @@ void Layer::setup_error_signals_tensor(const std::array<Dist, dc::num_dists> &di
                         << "error signals: " << m_error_signals_t;
 }
 
-// REVIEW: distconv-3d
 void Layer::setup_error_signals_copyout_tensor(const std::array<Dist, dc::num_dists> &dists) {
   const Shape input_tensor_shape = get_input_tensor_shape();
   const LocaleMPI loc(dc::get_mpi_comm(), false);
@@ -1829,7 +1821,6 @@ TensorShuffler *get_shuffler(Layer *layer,
                              TensorShuffler **last_mb_shufflers,
                              const TensorDev &src,
                              const TensorDev &dst) {
-  // REVIEW: distconv-3d
   TensorShuffler *shuffler = nullptr;
   if (layer->get_model()->get_max_mini_batch_size() ==
       layer->get_model()->get_current_mini_batch_size()) {

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1774,8 +1774,8 @@ bool model::save_model() {
 
 #ifdef LBANN_HAS_DISTCONV
 void model::setup_distconv() {
-  // Dist[4]: {x, y, dx, dy}
-  std::map<const Layer*, std::array<dc::Dist, 4>> dists;
+  // Dist[dc::num_dists]: {x, y, dx, dy}
+  std::map<const Layer*, std::array<dc::Dist, dc::num_dists>> dists;
   std::map<dc::Dist*, std::set<dc::Dist*>> invariants;
   std::set<dc::Dist*> updated;
   std::set<dc::Dist*> fixed;

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -243,6 +243,9 @@ std::vector<std::unique_ptr<Layer>> construct_layer_graph(
     ps.filter_groups = proto_layer.parallel_strategy().filter_groups();
     ps.filter_splits = proto_layer.parallel_strategy().filter_splits();
     ps.replications = proto_layer.parallel_strategy().replications();
+    // TODO: distconv-3d, do not define if num_dims == 4
+    ps.depth_groups = proto_layer.parallel_strategy().depth_groups();
+    ps.depth_splits = proto_layer.parallel_strategy().depth_splits();
 
     // Check that layer has been constructed
     if (l == nullptr) {

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -243,7 +243,7 @@ std::vector<std::unique_ptr<Layer>> construct_layer_graph(
     ps.filter_groups = proto_layer.parallel_strategy().filter_groups();
     ps.filter_splits = proto_layer.parallel_strategy().filter_splits();
     ps.replications = proto_layer.parallel_strategy().replications();
-    // TODO: distconv-3d, do not define if num_dims == 4
+    // FIXME: distconv-3d
     ps.depth_groups = proto_layer.parallel_strategy().depth_groups();
     ps.depth_splits = proto_layer.parallel_strategy().depth_splits();
 

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -243,10 +243,10 @@ std::vector<std::unique_ptr<Layer>> construct_layer_graph(
     ps.filter_groups = proto_layer.parallel_strategy().filter_groups();
     ps.filter_splits = proto_layer.parallel_strategy().filter_splits();
     ps.replications = proto_layer.parallel_strategy().replications();
-#ifdef DISTCONV_HAS_DEPTH
+#ifdef LBANN_DISTCONV_HAS_DEPTH
     ps.depth_groups = proto_layer.parallel_strategy().depth_groups();
     ps.depth_splits = proto_layer.parallel_strategy().depth_splits();
-#endif // DISTCONV_HAS_DEPTH
+#endif // LBANN_DISTCONV_HAS_DEPTH
 
     // Check that layer has been constructed
     if (l == nullptr) {

--- a/src/proto/factories/layer_graph_factory.cpp
+++ b/src/proto/factories/layer_graph_factory.cpp
@@ -243,9 +243,10 @@ std::vector<std::unique_ptr<Layer>> construct_layer_graph(
     ps.filter_groups = proto_layer.parallel_strategy().filter_groups();
     ps.filter_splits = proto_layer.parallel_strategy().filter_splits();
     ps.replications = proto_layer.parallel_strategy().replications();
-    // FIXME: distconv-3d
+#ifdef DISTCONV_HAS_DEPTH
     ps.depth_groups = proto_layer.parallel_strategy().depth_groups();
     ps.depth_splits = proto_layer.parallel_strategy().depth_splits();
+#endif // DISTCONV_HAS_DEPTH
 
     // Check that layer has been constructed
     if (l == nullptr) {

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -741,6 +741,8 @@ message ParallelStrategy {
   // For fully-connected layers.
   int64 replications = 11;
   int64 procs_per_replica = 12;
+  int64 depth_groups = 13; // TODO: enable/disable by CMake
+  int64 depth_splits = 14;
 }
 
 //========================================================================

--- a/src/proto/lbann.proto
+++ b/src/proto/lbann.proto
@@ -741,7 +741,7 @@ message ParallelStrategy {
   // For fully-connected layers.
   int64 replications = 11;
   int64 procs_per_replica = 12;
-  int64 depth_groups = 13; // TODO: enable/disable by CMake
+  int64 depth_groups = 13; // The depth fields will be ignored if num_dims < 4.
   int64 depth_splits = 14;
 }
 


### PR DESCRIPTION
This PR supports training of 3D CNNs with Distconv.
Users have to choose the number of dimensions of Distconv-enabled layers by passing `--distconv-num-dims 4_or_5` to `scripts/build_lbann_lc.sh` in advance.

This also adds the support of `parallel_strategy` for the Python frontend.