### PR TITLE
Change the data type for input/output sizes from int to El::int

### DIFF
--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -334,11 +334,11 @@ public:
   /** Get input tensor dimensions. */
   std::vector<int> get_input_dims(int input_index = 0) const;
   /** Get input tensor size. */
-  int get_input_size(int input_index = 0) const;
+  El::Int get_input_size(int input_index = 0) const;
   /** Get output tensor dimensions. */
   std::vector<int> get_output_dims(int output_index = 0) const;
   /** Get output tensor size. */
-  int get_output_size(int output_index = 0) const;
+  El::Int get_output_size(int output_index = 0) const;
 
   /** Set output tensor dimensions. */
   void set_output_dims(std::vector<int> dims, int output_index = 0);

--- a/src/data_readers/data_reader_numpy_npz.cpp
+++ b/src/data_readers/data_reader_numpy_npz.cpp
@@ -174,7 +174,7 @@ numpy_npz_reader::numpy_npz_reader(const bool shuffle, const bool placeholder)
 
     if (m_data.word_size == 2) {
       // Convert int16 to DataType.
-      const short *data = m_data.data<short>() + data_id * m_num_features;
+      const short *data = m_data.data<short>() + (size_t) data_id * m_num_features;
       DataType *dest = X_v.Buffer();
 
       // OPTIMIZE
@@ -185,11 +185,11 @@ numpy_npz_reader::numpy_npz_reader(const bool shuffle, const bool placeholder)
     } else {
       void *data = NULL;
       if (m_data.word_size == 4) {
-        data = (void *) (m_data.data<float>() + data_id * m_num_features);
+        data = (void *) (m_data.data<float>() + (size_t) data_id * m_num_features);
       } else if (m_data.word_size == 8) {
-        data = (void *) (m_data.data<double>() + data_id * m_num_features);
+        data = (void *) (m_data.data<double>() + (size_t) data_id * m_num_features);
       }
-      std::memcpy(X_v.Buffer(), data, m_num_features * m_data.word_size);
+      std::memcpy(X_v.Buffer(), data, (size_t) m_num_features * m_data.word_size);
     }
     return true;
   }

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -442,13 +442,13 @@ std::vector<int> Layer::get_input_dims(int input_index) const {
 
 }
 
-int Layer::get_input_size(int input_index) const {
+El::Int Layer::get_input_size(int input_index) const {
   const auto& dims = get_input_dims(input_index);
   if (dims.empty()) {
     return 0;
   } else {
     return std::accumulate(dims.begin(), dims.end(), 1,
-                           std::multiplies<int>());
+                           std::multiplies<El::Int>());
   }
 }
 
@@ -471,13 +471,13 @@ std::vector<int> Layer::get_output_dims(int output_index) const {
   return m_output_dims_list[output_index];
 }
 
-int Layer::get_output_size(int output_index) const {
+El::Int Layer::get_output_size(int output_index) const {
   const auto& dims = get_output_dims(output_index);
   if (dims.empty()) {
     return 0;
   } else {
     return std::accumulate(dims.begin(), dims.end(), 1,
-                           std::multiplies<int>());
+                           std::multiplies<El::Int>());
   }
 }
 


### PR DESCRIPTION
This PR changes the the data type for input/output sizes from `int` to `El::int`, so that sizes bigger than `int` are appropriately handled.