### PR TITLE
Input shuffling at the input layer

### DIFF
--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -556,6 +556,7 @@ protected:
   void setup_inter_layer_adaptation();
   void setup_early_termination();
   void setup_keep_original_tensors();
+  static dc::Dist get_hydrogen_matrix_distribution();
   virtual void setup_tensor_distribution_init(
       std::map<const Layer*, std::array<lbann::dc::Dist, dc::num_dists>> &dists,
       std::map<dc::Dist*, std::set<dc::Dist*>> &invariants,
@@ -565,6 +566,9 @@ protected:
       std::map<const Layer*, std::array<dc::Dist, dc::num_dists>> &dists,
       std::map<dc::Dist*, std::set<dc::Dist*>> &invariants);
   virtual size_t estimate_memory_usage(const std::array<dc::Dist, dc::num_dists> &dists);
+  /** Return Distconv-related shapes. */
+  const dc::Shape get_input_tensor_shape() const;
+  const dc::Shape get_output_tensor_shape() const;
   virtual void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dists> &dists) {}
   virtual void setup_prev_activations_tensor(const std::array<dc::Dist, dc::num_dists> &dists);
   virtual dc::Shape get_activations_tensor_local_shape() const;
@@ -684,10 +688,6 @@ private:
   const AbsDistMat& get_activations(const Layer& child) const;
   /** Get error signal tensor corresponding to parent layer. */
   const AbsDistMat& get_error_signals(const Layer& parent) const;
-
-  /** Return Distconv-related shapes. */
-  const dc::Shape get_input_tensor_shape() const;
-  const dc::Shape get_output_tensor_shape() const;
 
   // ===========================================================
   // Private class members

--- a/include/lbann/layers/transform/split.hpp
+++ b/include/lbann/layers/transform/split.hpp
@@ -89,6 +89,24 @@ protected:
   void fp_compute_distconv() {}
 
  public:
+
+  void setup_tensor_distribution_init(
+      std::map<const Layer*, std::array<lbann::dc::Dist, dc::num_dists>> &dists,
+      std::map<dc::Dist*, std::set<dc::Dist*>> &invariants,
+      std::set<dc::Dist*> &updated,
+      std::set<dc::Dist*> &fixed) {
+    Layer::setup_tensor_distribution_init(
+        dists, invariants, updated, fixed);
+    if (!distconv_enabled()) return;
+    auto &layer_dists = dists[this];
+    // x == y
+    invariants[&layer_dists[0]].insert(&layer_dists[1]);
+    invariants[&layer_dists[1]].insert(&layer_dists[0]);
+    // dx == dy
+    invariants[&layer_dists[2]].insert(&layer_dists[3]);
+    invariants[&layer_dists[3]].insert(&layer_dists[2]);
+  }
+
   void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dists> &dists) override {
     Layer::setup_tensors_fwd(dists);
     if (!this->distconv_enabled()) return;

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -47,10 +47,11 @@
 
 #include "distconv/distconv.hpp"
 #include "distconv/tensor/tensor_mpi_cuda.hpp"
-#include "distconv/tensor/shuffle.hpp"
-#include "distconv/tensor/shuffle_p2p.hpp"
-#include "distconv/tensor/shuffle_al.hpp"
-#include "distconv/tensor/shuffle_hybrid.hpp"
+#include "distconv/tensor/shuffle_mpi.hpp"
+#include "distconv/tensor/shuffle_mpi_cuda.hpp"
+#include "distconv/tensor/shuffle_mpi_cuda_p2p.hpp"
+#include "distconv/tensor/shuffle_mpi_cuda_al.hpp"
+#include "distconv/tensor/shuffle_mpi_cuda_hybrid.hpp"
 #include "distconv/tensor/algorithms.hpp"
 #include "distconv/util/util.hpp"
 #include "p2p/p2p.hpp"
@@ -72,11 +73,14 @@ using Shape = ::distconv::tensor::Shape;
 
 using TensorHost = ::distconv::tensor::Tensor<
   DataType, ::distconv::tensor::LocaleMPI,
-  ::distconv::tensor::CUDAAllocator>;
+  ::distconv::tensor::BaseAllocator>;
 
 using TensorDev = ::distconv::tensor::Tensor<
   DataType, ::distconv::tensor::LocaleMPI,
   ::distconv::tensor::CUDAAllocator>;
+
+using TensorHostShuffler = ::distconv::tensor::TensorMPIShuffler<
+  DataType, ::distconv::tensor::BaseAllocator>;
 
 using TensorShuffler = ::distconv::tensor::TensorMPICUDAShuffler<DataType>;
 using TensorShufflerP2P = ::distconv::tensor::TensorMPICUDAShufflerP2P<DataType>;

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -95,9 +95,11 @@ using LocaleMPI = ::distconv::tensor::LocaleMPI;
 using MPIPrintStreamDebug = ::distconv::util::MPIPrintStreamDebug;
 using MPIPrintStreamError = ::distconv::util::MPIPrintStreamError;
 using MPIPrintStreamInfo = ::distconv::util::MPIPrintStreamInfo;
+using MPIPrintStreamWarning = ::distconv::util::MPIPrintStreamWarning;
 using MPIRootPrintStreamDebug = ::distconv::util::MPIRootPrintStreamDebug;
 using MPIRootPrintStreamError = ::distconv::util::MPIRootPrintStreamError;
 using MPIRootPrintStreamInfo = ::distconv::util::MPIRootPrintStreamInfo;
+using MPIRootPrintStreamWaning = ::distconv::util::MPIRootPrintStreamWarning;
 
 using Backend = ::distconv::cudnn::BackendCUDNN;
 using ReLU = ::distconv::ReLU<Backend>;

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1336,17 +1336,6 @@ void Layer::setup_inter_layer_adaptation() {
   if (!distconv_enabled()) return;
 
   MPIRootPrintStreamInfo() << get_name() << ": setup_copyin_copyout";
-  const auto &child_layers = get_child_layers();
-  MPIPrintStreamDebug()
-      << ": number of children: " << child_layers.size()
-      << ", child name: "
-      << (child_layers.size() > 0 ? child_layers[0]->get_name() : "not available");
-
-  const auto &parent_layers = get_parent_layers();
-  MPIPrintStreamDebug()
-      << ": number of parents: " << parent_layers.size()
-      << ", parent name: " << (parent_layers.size() > 0 ? parent_layers[0]->get_name() : "not available");
-
   const auto &ps = get_parallel_strategy();
   m_parent_copy_in_required = false;
   m_parent_shuffle_required = false;
@@ -1540,8 +1529,7 @@ void Layer::setup_tensor_distribution_add_adjacent_invariants(
   }
 }
 
-namespace {
-Dist get_hydrogen_matrix_distribution() {
+Dist Layer::get_hydrogen_matrix_distribution() {
   using ::distconv::index_t;
   // When rank stride is 1, the distribution is just sample
   // distribution. When it's greater than 1, multiple consecutive
@@ -1558,7 +1546,6 @@ Dist get_hydrogen_matrix_distribution() {
       (sample_locale_shape, sample_split_shape);
   return sample_dist;
 }
-} // namespace
 
 size_t Layer::estimate_memory_usage(const std::array<Dist, dc::num_dists> &dists) {
   if (!distconv_enabled()) {

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -809,7 +809,6 @@ std::unique_ptr<AbsDistMat> Layer::construct_matrix(const El::Grid& grid,
 }
 
 void Layer::setup_data() {
-
   // Get mini-batch size
   const auto& mini_batch_size = m_model->get_max_mini_batch_size();
 
@@ -1264,6 +1263,9 @@ bool Layer::using_distconv() const {
   const auto &ps = get_parallel_strategy();
   ParallelStrategy default_zero_ps;
   if (ps == default_zero_ps) {
+    MPIRootPrintStreamInfo()
+        << "Disable " << get_name()
+        << " as it does not have a parallel strategy.";
     return false;
   }
 

--- a/src/utils/distconv.cpp
+++ b/src/utils/distconv.cpp
@@ -357,6 +357,10 @@ HaloExchangeMethod get_halo_exchange_method() {
 
 TensorShuffler *get_tensor_shuffler(const TensorDev &src,
                                     const TensorDev &dst) {
+  dc::MPIPrintStreamDebug()
+      << "Available memory: " <<
+      cuda::get_available_memory_capacity() / 1024.0 / 1024.0
+      << " MB";
   if (opt_tensor_shuffler == "AL") {
     return new TensorShufflerAL(src, dst, get_mpicuda());
   } else if (opt_tensor_shuffler == "HYBRID") {

--- a/src/utils/lbann_library.cpp
+++ b/src/utils/lbann_library.cpp
@@ -63,176 +63,170 @@ model *build_model_from_prototext(int argc, char **argv,
   bool master = comm->am_world_master();
   if (master) std::cerr << "starting build_model_from_prototext\n";
   model *model = nullptr; //d hysom bad namimg! should fix
-  try {
-    std::stringstream err;
-    options *opts = options::get();
 
-    // Optionally over-ride some values in prototext
-    get_cmdline_overrides(comm, pb);
+  std::stringstream err;
+  options *opts = options::get();
 
-    customize_data_readers_index_list(comm, pb);
+  // Optionally over-ride some values in prototext
+  get_cmdline_overrides(comm, pb);
 
-    lbann_data::Model *pb_model = pb.mutable_model();
+  customize_data_readers_index_list(comm, pb);
 
-    // Adjust the number of parallel readers; this may be adjusted
-    // after calling split_trainers()
-    set_num_parallel_readers(comm, pb);
+  lbann_data::Model *pb_model = pb.mutable_model();
 
-    // Check to see if the model wants to reduce the I/O parallelism
-    if(pb_model->serialize_background_io() && io_thread_pool->get_num_threads() != 1) {
-      if(master) {
-        std::cout << "Model " << pb_model->name() << " serialized the background I/O threads" << std::endl;
-      }
-      io_thread_pool->relaunch_pinned_threads(1);
+  // Adjust the number of parallel readers; this may be adjusted
+  // after calling split_trainers()
+  set_num_parallel_readers(comm, pb);
+
+  // Check to see if the model wants to reduce the I/O parallelism
+  if(pb_model->serialize_background_io() && io_thread_pool->get_num_threads() != 1) {
+    if(master) {
+      std::cout << "Model " << pb_model->name() << " serialized the background I/O threads" << std::endl;
     }
-
-    // Setup I/O threads
-    auto io_threads_per_process = io_thread_pool->get_num_threads();
-    auto io_threads_offset = io_thread_pool->get_threads_offset();
-
-    // Set algorithmic blocksize
-    if (pb_model->block_size() == 0 and master) {
-      err << "model does not provide a valid block size (" << pb_model->block_size() << ")";
-      LBANN_ERROR(err.str());
-    }
-    El::SetBlocksize(pb_model->block_size());
-
-    // Change random seed if needed.
-    if (pb_model->random_seed() > 0) {
-      random_seed = pb_model->random_seed();
-      // Reseed here so that setup is done with this new seed.
-      init_random(random_seed);
-      init_data_seq_random(random_seed);
-    }
-    // Initialize models differently if needed.
-#ifndef LBANN_DETERMINISTIC
-    if (pb_model->random_init_models_differently()) {
-      random_seed = random_seed + comm->get_trainer_rank();
-      // Reseed here so that setup is done with this new seed.
-      init_random(random_seed);
-      init_data_seq_random(random_seed);
-    }
-#else
-    if (pb_model->random_init_models_differently()) {
-      if (master) {
-        std::cout << "WARNING: Ignoring random_init_models_differently " <<
-          "due to sequential consistency" << std::endl;
-      }
-    }
-#endif
-
-    // Set up the communicator and get the grid based on the first model's spec.
-    // We do not currently support splitting different models in different ways,
-    // as this implies different grids.
-    int procs_per_trainer = pb_model->procs_per_trainer();
-    if (procs_per_trainer == 0) {
-      procs_per_trainer = comm->get_procs_in_world();
-    }
-    if (first_model) {
-      //comm->split_trainers(procs_per_trainer);
-      if (pb_model->num_parallel_readers() > procs_per_trainer) {
-        pb_model->set_num_parallel_readers(procs_per_trainer);
-      }
-    } else if (procs_per_trainer != comm->get_procs_per_trainer()) {
-      LBANN_ERROR("Model prototexts requesting different procs per model is not supported");
-    }
-
-    // Save info to file; this includes the complete prototext (with any over-rides
-    // from the cmd line) and various other info
-    save_session(comm, argc, argv, pb);
-
-    // Report useful information
-    if (master) {
-      print_lbann_configuration(pb_model, comm, io_threads_per_process, io_threads_offset);
-    }
-
-    // Display how the OpenMP threads are provisioned
-    if (opts->has_string("print_affinity")) {
-      display_omp_setup();
-    }
-
-    // Initialize data readers
-    //@todo: code not in place for correctly handling image preprocessing
-    std::map<execution_mode, generic_data_reader *> data_readers;
-    bool is_shared_training_data_reader = pb_model->shareable_training_data_reader();
-    bool is_shared_testing_data_reader = pb_model->shareable_testing_data_reader();
-    if (opts->has_string("share_testing_data_readers")) {
-      is_shared_testing_data_reader = opts->get_bool("share_testing_data_readers");
-    }
-    init_data_readers(comm, pb, data_readers, is_shared_training_data_reader, is_shared_testing_data_reader);
-
-    // hack to prevent all data readers from loading identical data; instead,
-    // share a single copy. See data_reader_jag_conduit_hdf5 for example
-    if (first_model) {
-      if (opts->has_string("share_data_reader_data")) {
-        for (auto t : data_readers) {
-          opts->set_ptr((void*)t.second);
-        }
-      }
-    }
-
-    // User feedback
-    print_parameters(comm, pb);
-
-    // Initalize model
-    model = proto::construct_model(comm,
-                                   data_readers,
-                                   pb.optimizer(),
-                                   pb.model());
-    model->setup(io_thread_pool);
-
-    if(opts->get_bool("disable_background_io_activity")) {
-      model->allow_background_io_activity(false);
-    }
-
-    //under development; experimental
-    if (opts->has_bool("use_data_store") && opts->get_bool("use_data_store")) {
-      if (master) {
-        std::cout << "\nUSING DATA STORE!\n\n";
-      }
-      for (auto r : data_readers) {
-        if (!r.second) continue;
-        r.second->setup_data_store(model);
-      }
-    }
-
-    if (opts->has_string("create_tarball")) {
-      finalize(comm);
-      return 0;
-    }
-
-    // restart model from checkpoint if we have one
-    //@todo
-    //model->restartShared();
-
-    if (comm->am_world_master()) {
-      std::cout << std::endl;
-      std::cout << model->get_description();
-      std::cout << "Callbacks:" << std::endl;
-      for (lbann_callback *cb : model->get_callbacks()) {
-        std::cout << cb->name() << std::endl;
-      }
-    }
-
-#ifndef LBANN_DETERMINISTIC
-      // Under normal conditions, reinitialize the random number generator so
-      // that regularization techniques (e.g. dropout) generate unique patterns
-      // on different ranks.
-      init_random(random_seed + comm->get_rank_in_world());
-#else
-      if(comm->am_world_master()) {
-        std::cout <<
-          "--------------------------------------------------------------------------------\n"
-          "ALERT: executing in sequentially consistent mode -- performance will suffer\n"
-          "--------------------------------------------------------------------------------\n";
-      }
-#endif
-
-  } catch (lbann_exception& e) {
-    El::mpi::Abort(El::mpi::COMM_WORLD, 1);
-  } catch (std::exception& e) {
-    El::ReportException(e);  // Elemental exceptions
+    io_thread_pool->relaunch_pinned_threads(1);
   }
+
+  // Setup I/O threads
+  auto io_threads_per_process = io_thread_pool->get_num_threads();
+  auto io_threads_offset = io_thread_pool->get_threads_offset();
+
+  // Set algorithmic blocksize
+  if (pb_model->block_size() == 0 and master) {
+    err << "model does not provide a valid block size (" << pb_model->block_size() << ")";
+    LBANN_ERROR(err.str());
+  }
+  El::SetBlocksize(pb_model->block_size());
+
+  // Change random seed if needed.
+  if (pb_model->random_seed() > 0) {
+    random_seed = pb_model->random_seed();
+    // Reseed here so that setup is done with this new seed.
+    init_random(random_seed);
+    init_data_seq_random(random_seed);
+  }
+  // Initialize models differently if needed.
+#ifndef LBANN_DETERMINISTIC
+  if (pb_model->random_init_models_differently()) {
+    random_seed = random_seed + comm->get_trainer_rank();
+    // Reseed here so that setup is done with this new seed.
+    init_random(random_seed);
+    init_data_seq_random(random_seed);
+  }
+#else
+  if (pb_model->random_init_models_differently()) {
+    if (master) {
+      std::cout << "WARNING: Ignoring random_init_models_differently " <<
+          "due to sequential consistency" << std::endl;
+    }
+  }
+#endif
+
+  // Set up the communicator and get the grid based on the first model's spec.
+  // We do not currently support splitting different models in different ways,
+  // as this implies different grids.
+  int procs_per_trainer = pb_model->procs_per_trainer();
+  if (procs_per_trainer == 0) {
+    procs_per_trainer = comm->get_procs_in_world();
+  }
+  if (first_model) {
+    //comm->split_trainers(procs_per_trainer);
+    if (pb_model->num_parallel_readers() > procs_per_trainer) {
+      pb_model->set_num_parallel_readers(procs_per_trainer);
+    }
+  } else if (procs_per_trainer != comm->get_procs_per_trainer()) {
+    LBANN_ERROR("Model prototexts requesting different procs per model is not supported");
+  }
+
+  // Save info to file; this includes the complete prototext (with any over-rides
+  // from the cmd line) and various other info
+  save_session(comm, argc, argv, pb);
+
+  // Report useful information
+  if (master) {
+    print_lbann_configuration(pb_model, comm, io_threads_per_process, io_threads_offset);
+  }
+
+  // Display how the OpenMP threads are provisioned
+  if (opts->has_string("print_affinity")) {
+    display_omp_setup();
+  }
+
+  // Initialize data readers
+  //@todo: code not in place for correctly handling image preprocessing
+  std::map<execution_mode, generic_data_reader *> data_readers;
+  bool is_shared_training_data_reader = pb_model->shareable_training_data_reader();
+  bool is_shared_testing_data_reader = pb_model->shareable_testing_data_reader();
+  if (opts->has_string("share_testing_data_readers")) {
+    is_shared_testing_data_reader = opts->get_bool("share_testing_data_readers");
+  }
+  init_data_readers(comm, pb, data_readers, is_shared_training_data_reader, is_shared_testing_data_reader);
+
+  // hack to prevent all data readers from loading identical data; instead,
+  // share a single copy. See data_reader_jag_conduit_hdf5 for example
+  if (first_model) {
+    if (opts->has_string("share_data_reader_data")) {
+      for (auto t : data_readers) {
+        opts->set_ptr((void*)t.second);
+      }
+    }
+  }
+
+  // User feedback
+  print_parameters(comm, pb);
+
+  // Initalize model
+  model = proto::construct_model(comm,
+                                 data_readers,
+                                 pb.optimizer(),
+                                 pb.model());
+  model->setup(io_thread_pool);
+
+  if(opts->get_bool("disable_background_io_activity")) {
+    model->allow_background_io_activity(false);
+  }
+
+  //under development; experimental
+  if (opts->has_bool("use_data_store") && opts->get_bool("use_data_store")) {
+    if (master) {
+      std::cout << "\nUSING DATA STORE!\n\n";
+    }
+    for (auto r : data_readers) {
+      if (!r.second) continue;
+      r.second->setup_data_store(model);
+    }
+  }
+
+  if (opts->has_string("create_tarball")) {
+    finalize(comm);
+    return 0;
+  }
+
+  // restart model from checkpoint if we have one
+  //@todo
+  //model->restartShared();
+
+  if (comm->am_world_master()) {
+    std::cout << std::endl;
+    std::cout << model->get_description();
+    std::cout << "Callbacks:" << std::endl;
+    for (lbann_callback *cb : model->get_callbacks()) {
+      std::cout << cb->name() << std::endl;
+    }
+  }
+
+#ifndef LBANN_DETERMINISTIC
+  // Under normal conditions, reinitialize the random number generator so
+  // that regularization techniques (e.g. dropout) generate unique patterns
+  // on different ranks.
+  init_random(random_seed + comm->get_rank_in_world());
+#else
+  if(comm->am_world_master()) {
+    std::cout <<
+        "--------------------------------------------------------------------------------\n"
+        "ALERT: executing in sequentially consistent mode -- performance will suffer\n"
+        "--------------------------------------------------------------------------------\n";
+  }
+#endif
 
   return model;
 }


### PR DESCRIPTION
When a parallel strategy is set, the input layer shuffles samples on CPU. When background I/O is enabled, shuffling is also done as part of the background task.

This should not affect anything if the input layer is not attached with a parallel strategy.