### PR TITLE
Disables zeroing out some matrices related to sample reading.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,8 @@ option(LBANN_WITH_P2P
 set(LBANN_DATATYPE "float"
   CACHE STRING "The datatype to use in LBANN")
 
+option(LBANN_IO_DISABLE_ZEROS "Disable zero-clearing of matrices at data loading" ON)
+
 #
 # Initialize build
 #

--- a/cmake/configure_files/lbann_config.hpp.in
+++ b/cmake/configure_files/lbann_config.hpp.in
@@ -63,4 +63,6 @@ namespace lbann
 using DataType = @LBANN_DATATYPE@;
 }// namespace lbann
 
+#cmakedefine LBANN_IO_DISABLE_ZEROS
+
 #endif /* LBANN_CONFIG_H__ */


### PR DESCRIPTION
It does so by default, but can be controlled LBANN_IO_DISABLE_ZEROS
CMake option.