### PR TITLE
Apply input normalization on GPUs

### DIFF
--- a/src/data_readers/data_reader_numpy_npz_conduit.cpp
+++ b/src/data_readers/data_reader_numpy_npz_conduit.cpp
@@ -227,22 +227,11 @@ bool numpy_npz_conduit_reader::fetch_datum(Mat& X, int data_id, int mb_idx) {
     // Convert int16 to DataType.
     short *data = reinterpret_cast<short*>(char_data_2);
     DataType *dest = X_v.Buffer();
-
-    const float stds[] = {6.756270281,5.244487988,3.027853968,1.58000543};
-
-    bool normalize = std::getenv("COSMOFLOW_NORMALIZE_INPUT") != nullptr;
-    if (normalize) {
-      LBANN_OMP_PARALLEL_FOR
-      for(int j = 0; j < m_num_features; j++) {
-        dest[j] = ((DataType)data[j] - 1.0f) / stds[(j>>27)&3];
-      }
-    } else {
-      // OPTIMIZE
-      LBANN_OMP_PARALLEL_FOR
-      for(int j = 0; j < m_num_features; j++) {
-        dest[j] = data[j] * m_scaling_factor_int16;
-      }
-    }
+    // OPTIMIZE
+    LBANN_OMP_PARALLEL_FOR
+        for(int j = 0; j < m_num_features; j++) {
+          dest[j] = data[j] * m_scaling_factor_int16;
+        }
   } else {
     void *data = (void*)char_data_2;
     std::memcpy(X_v.Buffer(), data, m_num_features * m_data_word_size);


### PR DESCRIPTION
This PR implements input data normalization on GPUs.
When an environment variable `COSMOFLOW_NORMALIZE_ALPHA` is defined, the linear transformation (`dest = COSMOFLOW_NORMALIZE_ALPHA * src + COSMOFLOW_NORMALIZE_BETA`) is applied on GPUs after input data shuffle is completed.
This also removes the normalization function on the CPU side as it is no longer used.