### PR TITLE
Slab support in data store

### DIFF
--- a/include/lbann/data_readers/CMakeLists.txt
+++ b/include/lbann/data_readers/CMakeLists.txt
@@ -2,6 +2,7 @@
 set_full_path(THIS_DIR_HEADERS
   compound_data_reader.hpp
   data_reader.hpp
+  data_reader_hdf5.hpp
   data_reader_cifar10.hpp
   data_reader_cosmoflow.hpp
   data_reader_csv.hpp

--- a/include/lbann/data_readers/data_reader_hdf5.hpp
+++ b/include/lbann/data_readers/data_reader_hdf5.hpp
@@ -17,6 +17,7 @@
 #define LBANN_DATA_READER_HDF5_HPP
 #include "data_reader_image.hpp"
 #include "hdf5.h"
+#include "conduit/conduit.hpp"
 
 namespace lbann {
 /**
@@ -25,7 +26,13 @@ namespace lbann {
 class hdf5_reader : public generic_data_reader {
  public:
   hdf5_reader(const bool shuffle);
+  hdf5_reader(const hdf5_reader&);
+  hdf5_reader& operator=(const hdf5_reader&);
+  ~hdf5_reader() override {}
+
   hdf5_reader* copy() const override { return new hdf5_reader(*this); }
+
+  void copy_members(const hdf5_reader& rhs);
 
   std::string get_type() const override {
     return "data_reader_hdf5_images";
@@ -48,7 +55,8 @@ class hdf5_reader : public generic_data_reader {
     return m_data_dims;
   }
  protected:
-  void read_hdf5(hsize_t h_data, hsize_t filespace, int rank, std::string key, hsize_t* dims, DataType * data_out);
+  void read_hdf5_hyperslab(hsize_t h_data, hsize_t filespace, int rank, std::string key, hsize_t* dims, conduit::Node& sample);
+  void read_hdf5_sample(int data_id, conduit::Node& sample);
   //void set_defaults() override;
   bool fetch_datum(CPUMat& X, int data_id, int mb_idx) override;
   bool fetch_label(CPUMat& Y, int data_id, int mb_idx) override;

--- a/include/lbann/data_readers/data_reader_hdf5.hpp
+++ b/include/lbann/data_readers/data_reader_hdf5.hpp
@@ -65,6 +65,8 @@ class hdf5_reader : public generic_data_reader {
   std::vector<std::string> m_file_paths;
   MPI_Comm m_comm;
   std::vector<int> m_data_dims;
+  hid_t m_fapl;
+  hid_t m_dxpl;
  private:
   static const std::string HDF5_KEY_DATA, HDF5_KEY_LABELS, HDF5_KEY_RESPONSES;
 };

--- a/include/lbann/data_readers/data_reader_hdf5.hpp
+++ b/include/lbann/data_readers/data_reader_hdf5.hpp
@@ -1,0 +1,57 @@
+// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+// // may not use this file except in compliance with the License.  You may
+// // obtain a copy of the License at:
+// //
+// // http://www.apache.org/licenses/LICENSE-2.0
+// //
+// // Unless required by applicable law or agreed to in writing, software
+// // distributed under the License is distributed on an "AS IS" BASIS,
+// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// // implied. See the License for the specific language governing
+// // permissions and limitations under the license.
+// //
+// ////////////////////////////////////////////////////////////////////////////////
+//
+//
+#ifndef LBANN_DATA_READER_HDF5_HPP
+#define LBANN_DATA_READER_HDF5_HPP
+#include "data_reader_image.hpp"
+#include "hdf5.h"
+
+namespace lbann {
+    /**
+     * Data reader for data stored in hdf5 files will need to assume the file contains x
+     */
+    class hdf5_reader : public generic_data_reader {
+    public:
+        hdf5_reader(const bool shuffle);
+        hdf5_reader* copy() const override { return new hdf5_reader(*this); }
+
+        std::string get_type() const override {
+            return "data_reader_hdf5_images"; 
+        }
+        //void set_input_params(int width, int height, int depth, int num_ch, int num_labels);
+        void load() override;
+        void set_hdf5_paths(const std::vector<std::string> hdf5_paths) {m_file_paths = hdf5_paths;}
+        void set_scaling_factor_int16(DataType s) {m_scaling_factor_int16 = s;}
+    protected:
+        void read_hdf5(hsize_t h_data, hsize_t filespace, int rank, std::string key, hsize_t* dims, DataType * data_out);
+        //void set_defaults() override;
+        bool fetch_datum(CPUMat& X, int data_id, int mb_idx) override;
+        bool fetch_label(CPUMat& Y, int data_id, int mb_idx) override;
+        bool fetch_response(CPUMat& Y, int data_id, int mb_idx) override;
+        /// Whether to fetch a label from the last column.
+        bool m_has_labels = false;
+        /// Whether to fetch a response from the last column.
+        bool m_has_responses = true;
+        int m_image_depth=0; 
+        int m_num_responses_features =4;
+        float m_all_responses[4];
+        DataType m_scaling_factor_int16 = 1.0;
+        std::vector<std::string> m_file_paths;
+        MPI_Comm m_comm;
+    private:
+        static const std::string HDF5_KEY_DATA, HDF5_KEY_LABELS, HDF5_KEY_RESPONSES;
+    };
+}
+#endif

--- a/include/lbann/data_readers/data_reader_hdf5.hpp
+++ b/include/lbann/data_readers/data_reader_hdf5.hpp
@@ -19,39 +19,54 @@
 #include "hdf5.h"
 
 namespace lbann {
-    /**
-     * Data reader for data stored in hdf5 files will need to assume the file contains x
-     */
-    class hdf5_reader : public generic_data_reader {
-    public:
-        hdf5_reader(const bool shuffle);
-        hdf5_reader* copy() const override { return new hdf5_reader(*this); }
+/**
+ * Data reader for data stored in hdf5 files will need to assume the file contains x
+ */
+class hdf5_reader : public generic_data_reader {
+ public:
+  hdf5_reader(const bool shuffle);
+  hdf5_reader* copy() const override { return new hdf5_reader(*this); }
 
-        std::string get_type() const override {
-            return "data_reader_hdf5_images"; 
-        }
-        //void set_input_params(int width, int height, int depth, int num_ch, int num_labels);
-        void load() override;
-        void set_hdf5_paths(const std::vector<std::string> hdf5_paths) {m_file_paths = hdf5_paths;}
-        void set_scaling_factor_int16(DataType s) {m_scaling_factor_int16 = s;}
-    protected:
-        void read_hdf5(hsize_t h_data, hsize_t filespace, int rank, std::string key, hsize_t* dims, DataType * data_out);
-        //void set_defaults() override;
-        bool fetch_datum(CPUMat& X, int data_id, int mb_idx) override;
-        bool fetch_label(CPUMat& Y, int data_id, int mb_idx) override;
-        bool fetch_response(CPUMat& Y, int data_id, int mb_idx) override;
-        /// Whether to fetch a label from the last column.
-        bool m_has_labels = false;
-        /// Whether to fetch a response from the last column.
-        bool m_has_responses = true;
-        int m_image_depth=0; 
-        int m_num_responses_features =4;
-        float m_all_responses[4];
-        DataType m_scaling_factor_int16 = 1.0;
-        std::vector<std::string> m_file_paths;
-        MPI_Comm m_comm;
-    private:
-        static const std::string HDF5_KEY_DATA, HDF5_KEY_LABELS, HDF5_KEY_RESPONSES;
-    };
+  std::string get_type() const override {
+    return "data_reader_hdf5_images";
+  }
+  //void set_input_params(int width, int height, int depth, int num_ch, int num_labels);
+  void load() override;
+  void set_hdf5_paths(const std::vector<std::string> hdf5_paths) {m_file_paths = hdf5_paths;}
+  void set_scaling_factor_int16(DataType s) {m_scaling_factor_int16 = s;}
+
+  int get_num_responses() const override {
+    return get_linearized_response_size();
+  }
+  int get_linearized_data_size() const override {
+    return m_num_features;
+  }
+  int get_linearized_response_size() const override {
+    return m_num_response_features;
+  }
+  const std::vector<int> get_data_dims() const override {
+    return m_data_dims;
+  }
+ protected:
+  void read_hdf5(hsize_t h_data, hsize_t filespace, int rank, std::string key, hsize_t* dims, DataType * data_out);
+  //void set_defaults() override;
+  bool fetch_datum(CPUMat& X, int data_id, int mb_idx) override;
+  bool fetch_label(CPUMat& Y, int data_id, int mb_idx) override;
+  bool fetch_response(CPUMat& Y, int data_id, int mb_idx) override;
+  /// Whether to fetch a label from the last column.
+  bool m_has_labels = false;
+  /// Whether to fetch a response from the last column.
+  bool m_has_responses = true;
+  int m_image_depth=0;
+  int m_num_features;
+  int m_num_response_features = 4;
+  float m_all_responses[4];
+  DataType m_scaling_factor_int16 = 1.0;
+  std::vector<std::string> m_file_paths;
+  MPI_Comm m_comm;
+  std::vector<int> m_data_dims;
+ private:
+  static const std::string HDF5_KEY_DATA, HDF5_KEY_LABELS, HDF5_KEY_RESPONSES;
+};
 }
 #endif

--- a/include/lbann/data_store/data_store_conduit.hpp
+++ b/include/lbann/data_store/data_store_conduit.hpp
@@ -47,6 +47,16 @@ namespace lbann {
 
 class generic_data_reader;
 
+/** Create a hash function for hashing a std::pair type */
+struct size_t_pair_hash
+{
+  template <class T1, class T2>
+  std::size_t operator() (const std::pair<T1, T2> &pair) const
+  {
+    return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
+  }
+};
+
 class data_store_conduit {
 
  public:
@@ -101,7 +111,7 @@ class data_store_conduit {
 
   /// As of this writing, will be called if cmd line includes: --preload_data_store
   /// This may change in the future; TODO revisit
-  void set_preload(); 
+  void set_preload();
 
   bool is_preloaded() { return m_preload; }
 
@@ -125,7 +135,7 @@ class data_store_conduit {
 
   bool is_local_cache() const { return m_is_local_cache; }
 
-  void exchange_mini_batch_data(size_t current_pos, size_t mb_size); 
+  void exchange_mini_batch_data(size_t current_pos, size_t mb_size);
 
   void set_super_node_mode() {
     m_super_node = true;
@@ -146,7 +156,7 @@ class data_store_conduit {
   /// made public for debugging during development
   void copy_members(const data_store_conduit& rhs, const std::vector<int>& = std::vector<int>());
 
-  void flush_debug_file(); 
+  void flush_debug_file();
 
 protected :
 
@@ -197,12 +207,16 @@ protected :
 
   /// rank in the trainer; convenience handle
   int  m_rank_in_trainer;
+  int  m_partition_in_trainer;
+  int  m_offset_in_partition;
 
   /// number of procs in the trainer; convenience handle
   int  m_np_in_trainer;
+  int  m_num_partitions_in_trainer;
 
   /// maps an index to the processor that owns the associated data
-  mutable std::unordered_map<int, int> m_owner;
+  /// First value of index is the sample ID and second value is the partiton ID
+  mutable std::unordered_map<std::pair<size_t,size_t>, int, size_t_pair_hash> m_owner;
 
   /// convenience handle
   const std::vector<int> *m_shuffled_indices;
@@ -292,7 +306,7 @@ protected :
   void build_conduit_nodes(std::unordered_map<int,size_t> &sizes);
 
   /// for use in local cache mode
-  void exchange_images(std::vector<char> &work, std::unordered_map<int,size_t> &image_sizes, std::vector<std::vector<int>> &indices); 
+  void exchange_images(std::vector<char> &work, std::unordered_map<int,size_t> &image_sizes, std::vector<std::vector<int>> &indices);
 
   /// for use in local cache mode
   void fillin_shared_images(const std::vector<char> &images, size_t offset);

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -967,6 +967,16 @@ class generic_input_layer : public io_layer {
     m_input_dev = TensorDevInput(tensor_shape, loc, dist);
     assert0(m_input_dev.allocate());
     m_input_dev.zero(dc::get_stream());
+
+    // Allocate pinned memory buffer for copying input
+    if (dc::is_cosmoflow_parallel_io_enabled()) {
+      CHECK_CUDA(cudaMallocHost(
+          &m_copy_pinned_buffer,
+          m_input_dev.get_local_real_size() * sizeof(InputType)));
+
+    } else {
+      m_copy_pinned_buffer = nullptr;
+    }
   }
 
   void setup_tensors_bwd(
@@ -1008,6 +1018,8 @@ class generic_input_layer : public io_layer {
   std::vector<std::unique_ptr<InputType>> m_input_shuffler_dst_bufs;
 
   TensorDevInput m_input_dev;
+
+  InputType *m_copy_pinned_buffer;
 
   TensorShuffler &get_shuffler(const TensorHost &src,
                                const TensorHost &dst,
@@ -1106,6 +1118,12 @@ class generic_input_layer : public io_layer {
           input_tensor.get_base_ptr());
     }
 
+    // After this, there is no inter-process communication, so it's
+    // safe to exit if the local tensor is empty.
+    if (input_tensor.get_local_size() == 0) {
+      return;
+    }
+
     dc::MPIPrintStreamDebug()
         << this->get_name()
         << ": Copy the host tensor to device tensor";
@@ -1113,8 +1131,31 @@ class generic_input_layer : public io_layer {
     // be the same except for overlapping width. Device copy should be
     // done with cudaMemcpy3D.
     prof_region_begin("copy-to-device", prof_colors[1], false);
-    assert0(dc::tensor::Copy(m_input_dev, input_tensor, dc::get_stream()));
+    // TODO: Copy doesn't seem to be working correctly, likely because
+    // of the additional halo region in the destination buffer. For
+    // now, avoid this with the manual copy below. Also, in the
+    // Cosmoflow case, "input_tensor" is not a pinned buffer.
+    if (!dc::is_cosmoflow_parallel_io_enabled()) {
+      assert0(dc::tensor::Copy(m_input_dev, input_tensor, dc::get_stream()));
+    } else {
+      int chan_dim = input_tensor.get_local_shape()[::distconv::get_channel_dim()];
+      size_t block_size = input_tensor.get_local_size() / chan_dim;
+      for (int i = 0; i < chan_dim; ++i) {
+        auto dev_off =
+            m_input_dev.get_local_offset(dc::IndexVector({0,0,0,i,0}));
+        auto host_off = block_size * i;
+        // First copy to temporary pinned buffer
+        std::memcpy(m_copy_pinned_buffer + dev_off,
+                    input_tensor.get_const_buffer() + host_off,
+                    sizeof(short) * block_size);
+      }
+      CHECK_CUDA(cudaMemcpyAsync(
+          m_input_dev.get_buffer(),  m_copy_pinned_buffer,
+          m_input_dev.get_local_real_size() * sizeof(InputType),
+          cudaMemcpyHostToDevice, dc::get_stream()));
+    }
     prof_region_end("copy-to-device", false);
+
     {
       const auto norm_alpha_p = std::getenv("COSMOFLOW_NORMALIZE_ALPHA");
       const auto norm_beta_p  = std::getenv("COSMOFLOW_NORMALIZE_BETA");

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -895,6 +895,8 @@ class generic_input_layer : public io_layer {
     // calculated by Distconv
     local_shape[dc::get_sample_dim()] = 0;
     const auto &dist = dists[1];
+    auto dist_no_halo = dist;
+    dist_no_halo.clear_overlap();
 
     // Use the same MPI communicator for both IO buffers. This seems
     // to work around MPI errors likely caused with the alltoallv for
@@ -903,40 +905,54 @@ class generic_input_layer : public io_layer {
     const LocaleMPI loc(dc::get_mpi_comm(), false);
 
     for (int i = 0; i < num_buffers; ++i) {
-      // Create a view to the host Elemental matrix
-      m_input_views.push_back(TensorHost(tensor_shape, loc,
+      if (dc::is_cosmoflow_parallel_io_enabled()) {
+        // Assumes the input buffer is already partitioned for
+        // Distconv
+        m_input_views.push_back(TensorHost(tensor_shape, loc,
+                                           dist_no_halo));
+        // Create a Distconv tensor at host memory.
+        m_input_tensors.push_back(TensorHost(tensor_shape, loc,
+                                             dist_no_halo));
+      } else {
+        // Create a view to the host Elemental matrix
+        m_input_views.push_back(TensorHost(tensor_shape, loc,
                                            sample_dist, local_shape));
-      // Create a Distconv tensor at host memory.
-      m_input_tensors.push_back(TensorHost(tensor_shape, loc, dist));
-      // TODO: This is a temporary hack. Should use
-      // CUDAHostPooledAllocator, but the shuffler is
-      // only specialized for BaseAllocator.
+        // Create a Distconv tensor at host memory.
+        m_input_tensors.push_back(TensorHost(tensor_shape, loc, dist));
+      }
+      if (!dc::is_cosmoflow_parallel_io_enabled()) {
+        // TODO: This is a temporary hack. Should use
+        // CUDAHostPooledAllocator, but the shuffler is
+        // only specialized for BaseAllocator.
 #if 0
-      assert0(m_input_tensors.back().allocate());
+        assert0(m_input_tensors.back().allocate());
 #else
-      size_t buf_size = m_input_tensors.back().get_local_real_size()
-          * sizeof(InputType);
-      dc::MPIPrintStreamInfo() << "buf size: " << buf_size;
-      InputType *buf = nullptr;
-      CHECK_CUDA(cudaMallocHost(&buf, buf_size));
-      // Note buf should be deallocated.
-      dc::tensor::View(m_input_tensors.back(), buf);
+        size_t buf_size = m_input_tensors.back().get_local_real_size()
+            * sizeof(InputType);
+        dc::MPIPrintStreamInfo() << "buf size: " << buf_size;
+        InputType *buf = nullptr;
+        CHECK_CUDA(cudaMallocHost(&buf, buf_size));
+        // Note buf should be deallocated.
+        dc::tensor::View(m_input_tensors.back(), buf);
 #endif
+      }
     }
 
-    // Setup the shuffle buffers
-    m_input_shufflers.resize(num_buffers);
-    size_t shuffler_src_size = TensorShuffler::get_buf_size(
-        m_input_views[0]);
-    size_t shuffler_dst_size = TensorShuffler::get_buf_size(
-        m_input_tensors[0]);
-    for (int i = 0; i < num_buffers; ++i) {
-      m_input_shuffler_src_bufs.push_back(
-          std::unique_ptr<InputType>(
-              static_cast<InputType*>(dc::util::aligned_malloc(shuffler_src_size))));
-      m_input_shuffler_dst_bufs.push_back(
-          std::unique_ptr<InputType>(
-              static_cast<InputType*>(dc::util::aligned_malloc(shuffler_dst_size))));
+    if (!dc::is_cosmoflow_parallel_io_enabled()) {
+      // Setup the shuffle buffers
+      m_input_shufflers.resize(num_buffers);
+      size_t shuffler_src_size = TensorShuffler::get_buf_size(
+          m_input_views[0]);
+      size_t shuffler_dst_size = TensorShuffler::get_buf_size(
+          m_input_tensors[0]);
+      for (int i = 0; i < num_buffers; ++i) {
+        m_input_shuffler_src_bufs.push_back(
+            std::unique_ptr<InputType>(
+                static_cast<InputType*>(dc::util::aligned_malloc(shuffler_src_size))));
+        m_input_shuffler_dst_bufs.push_back(
+            std::unique_ptr<InputType>(
+                static_cast<InputType*>(dc::util::aligned_malloc(shuffler_dst_size))));
+      }
     }
 
     // Layer::setup_activations_tensor does not work as it assumes
@@ -1075,14 +1091,20 @@ class generic_input_layer : public io_layer {
         get_activations().LockedBuffer()));
 #endif // LBANN_DISTCONV_COSMOFLOW_KEEP_INT16
 
-    dc::MPIPrintStreamDebug()
-        << this->get_name()
-        << ": Shuffle the input LBANN tensor to Distconv tensor with buf: "
-        << active_buffer;
+    if (dc::is_cosmoflow_parallel_io_enabled()) {
+      // The input buffer is assumed to be already partitioned
+      assert0(dc::tensor::View(
+          input_tensor, input_view.get_const_buffer()));
+    } else {
+      dc::MPIPrintStreamDebug()
+          << this->get_name()
+          << ": Shuffle the input LBANN tensor to Distconv tensor with buf: "
+          << active_buffer;
 
-    get_shuffler(input_view, input_tensor).shuffle_forward(
-        input_view.get_const_base_ptr(),
-        input_tensor.get_base_ptr());
+      get_shuffler(input_view, input_tensor).shuffle_forward(
+          input_view.get_const_base_ptr(),
+          input_tensor.get_base_ptr());
+    }
 
     dc::MPIPrintStreamDebug()
         << this->get_name()
@@ -1160,6 +1182,7 @@ class generic_input_layer : public io_layer {
     shuffler.shuffle_forward(
         input_view.get_const_base_ptr(), input_tensor.get_base_ptr());
   }
+
 #endif // LBANN_HAS_DISTCONV
 };
 

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -1075,7 +1075,7 @@ class generic_input_layer : public io_layer {
       return;
     }
 
-    assert_eq(mb_size * dc::get_number_of_io_partitions(), get_activations().Width());
+    //assert_eq(mb_size * dc::get_number_of_io_partitions(), get_activations().Width());
     input_view.set_outermost_dimension(mb_size);
     input_tensor.set_outermost_dimension(mb_size);
 

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -1059,7 +1059,7 @@ class generic_input_layer : public io_layer {
       return;
     }
 
-    assert_eq(mb_size, get_activations().Width());
+    assert_eq(mb_size * dc::get_number_of_io_partitions(), get_activations().Width());
     input_view.set_outermost_dimension(mb_size);
     input_tensor.set_outermost_dimension(mb_size);
 

--- a/include/lbann/lbann.hpp
+++ b/include/lbann/lbann.hpp
@@ -139,7 +139,7 @@
 #include "lbann/data_readers/data_reader_pilot2_molecular.hpp"
 #include "lbann/data_readers/data_reader_mesh.hpp"
 #include "lbann/data_readers/data_reader_python.hpp"
-
+#include "lbann/data_readers/data_reader_hdf5.hpp"
 /// Data stores
 #include "lbann/data_store/data_store_conduit.hpp"
 

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -115,6 +115,7 @@ namespace util = ::distconv::util;
 
 using ::distconv::get_sample_dim;
 
+int get_strided_mpi_rank(MPI_Comm comm);
 MPI_Comm get_strided_mpi_comm(MPI_Comm comm);
 
 /** Initialize Distconv
@@ -212,6 +213,12 @@ cudaStream_t get_stream();
 
 TensorShuffler *get_tensor_shuffler(const TensorDev &src,
                                     const TensorDev &dst);
+
+MPI_Comm get_input_comm(const lbann_comm &comm);
+/** Return the MPI rank when reading input dataset
+ */
+int get_input_rank(const lbann_comm &comm);
+
 } // namespace dc
 } // namespace lbann
 

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -188,6 +188,10 @@ bool is_deterministic();
  */
 int get_number_of_io_partitions();
 
+/** Query if Cosmoflow parallel I/O is enabled.
+ */
+bool is_cosmoflow_parallel_io_enabled();
+
 /** Get p2p handle
  */
 p2p::P2P &get_p2p();

--- a/include/lbann/utils/distconv.hpp
+++ b/include/lbann/utils/distconv.hpp
@@ -184,6 +184,10 @@ int get_number_of_pre_generated_synthetic_data();
  */
 bool is_deterministic();
 
+/** Query the number of partitions in the depth dimension.
+ */
+int get_number_of_io_partitions();
+
 /** Get p2p handle
  */
 p2p::P2P &get_p2p();

--- a/scripts/build_lbann_lc.sh
+++ b/scripts/build_lbann_lc.sh
@@ -341,7 +341,7 @@ fi
 if [ ${USE_MODULES} -ne 0 ]; then
     module load git
     module use /usr/workspace/wsb/brain/utils/coral/modulefiles
-    module load cmake/3.14.0
+    module load cmake/3.14.5
 else
     use git
 fi

--- a/spack_environments/developer_release_x86_64_cuda_spack.yaml
+++ b/spack_environments/developer_release_x86_64_cuda_spack.yaml
@@ -16,7 +16,8 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - conduit@master~doc~doxygen+hdf5~hdf5_compat+mpi+python+shared~silo
+  - hdf5+mpi~cxx~fortran
+  - conduit@master~doc~doxygen+mpi~hdf5_compat+mpi+python+shared~silo
   - cnpy@master build_type=RelWithDebInfo
   - opencv build_type=RelWithDebInfo ~calib3d+core~cuda~dnn~eigen+fast-math~features2d~flann~gtk+highgui+imgproc~ipp~ipp_iw~jasper~java+jpeg~lapack~ml~opencl~opencl_svm~openclamdblas~openclamdfft~openmp+png~powerpc~pthreads_pf~python~qt+shared~stitching~superres+tiff~ts~video~videoio~videostab~vsx~vtk+zlib
   - cereal

--- a/src/data_readers/CMakeLists.txt
+++ b/src/data_readers/CMakeLists.txt
@@ -6,6 +6,7 @@ set_full_path(THIS_DIR_SOURCES
   data_reader_csv.cpp
   data_reader_image.cpp
   data_reader_imagenet.cpp
+  data_reader_hdf5.cpp
   data_reader_jag.cpp
   data_reader_jag_conduit.cpp
   data_reader_merge_features.cpp

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -118,11 +118,6 @@ int lbann::generic_data_reader::fetch_data(CPUMat& X, El::Matrix<El::Int>& indic
   const int mb_size = std::min(El::Int{((end_pos - m_current_pos) + m_sample_stride - 1) / m_sample_stride},
       X.Width());
 
-  dc::MPIPrintStreamInfo() << "loaded batch size: " << loaded_batch_size
-                           << ", mb_size: " << mb_size
-                           << ", sample_stride: " << m_sample_stride
-                           << ", X.Width(): " << X.Width();
-
 #ifndef LBANN_IO_DISABLE_ZEROS
   prof_region_begin("fetch_data_zeros", prof_colors[0], false);
   El::Zeros_seq(X, X.Height(), X.Width());

--- a/src/data_readers/data_reader.cpp
+++ b/src/data_readers/data_reader.cpp
@@ -30,6 +30,7 @@
 #include "lbann/data_store/data_store_conduit.hpp"
 #include "lbann/utils/omp_pragma.hpp"
 #include "lbann/utils/profiling.hpp"
+#include "lbann/utils/distconv.hpp"
 #include "lbann/models/model.hpp"
 #include <omp.h>
 #include <future>
@@ -116,6 +117,11 @@ int lbann::generic_data_reader::fetch_data(CPUMat& X, El::Matrix<El::Int>& indic
   const int end_pos = std::min(static_cast<size_t>(m_current_pos+loaded_batch_size), m_shuffled_indices.size());
   const int mb_size = std::min(El::Int{((end_pos - m_current_pos) + m_sample_stride - 1) / m_sample_stride},
       X.Width());
+
+  dc::MPIPrintStreamInfo() << "loaded batch size: " << loaded_batch_size
+                           << ", mb_size: " << mb_size
+                           << ", sample_stride: " << m_sample_stride
+                           << ", X.Width(): " << X.Width();
 
 #ifndef LBANN_IO_DISABLE_ZEROS
   prof_region_begin("fetch_data_zeros", prof_colors[0], false);

--- a/src/data_readers/data_reader_hdf5.cpp
+++ b/src/data_readers/data_reader_hdf5.cpp
@@ -49,7 +49,7 @@ inline hid_t check_hdf5(hid_t hid, const char *file, int line) {
 
 namespace lbann {
   const std::string hdf5_reader::HDF5_KEY_DATA = "full";
-  const std::string hdf5_reader::HDF5_KEY_RESPONSES = "physPar";
+  const std::string hdf5_reader::HDF5_KEY_RESPONSES = "unitPar";
 
   hdf5_reader::hdf5_reader(const bool shuffle)
     : generic_data_reader(shuffle) {}

--- a/src/data_readers/data_reader_hdf5.cpp
+++ b/src/data_readers/data_reader_hdf5.cpp
@@ -1,0 +1,184 @@
+////////////////////////////////////////////////////////////////////////////////
+//// Copyright (c) 2014-2019, Lawrence Livermore National Security, LLC.
+//// Produced at the Lawrence Livermore National Laboratory.
+//// Written by the LBANN Research Team (B. Van Essen, et al.) listed in
+//// the CONTRIBUTORS file. <lbann-dev@llnl.gov>
+////
+//// LLNL-CODE-697807.
+//// All rights reserved.
+////
+//// This file is part of LBANN: Livermore Big Artificial Neural Network
+//// Toolkit. For details, see http://software.llnl.gov/LBANN or
+//// https://github.com/LLNL/LBANN.
+////
+//// Licensed under the Apache License, Version 2.0 (the "Licensee"); you
+//// may not use this file except in compliance with the License.  You may
+//// obtain a copy of the License at:
+////
+//// http://www.apache.org/licenses/LICENSE-2.0
+////
+//// Unless required by applicable law or agreed to in writing, software
+//// distributed under the License is distributed on an "AS IS" BASIS,
+//// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//// implied. See the License for the specific language governing
+//// permissions and limitations under the license.
+////
+///////////////////////////////////////////////////////////////////////////////////
+#include "lbann/data_readers/data_reader_hdf5.hpp"
+#include "lbann/utils/profiling.hpp"
+#include <cstdio>
+#include <string>
+#include <fstream>
+#include <unordered_set>
+#include <iostream>
+#include <cstring>
+#include "lbann/utils/distconv.hpp"
+namespace lbann {
+  const std::string hdf5_reader::HDF5_KEY_DATA = "full";
+  const std::string hdf5_reader::HDF5_KEY_RESPONSES = "physPar";
+
+  hdf5_reader::hdf5_reader(const bool shuffle)
+    : generic_data_reader(shuffle) {}
+
+  void hdf5_reader::read_hdf5(hsize_t h_data, hsize_t filespace, int rank, std::string key, hsize_t* dims, DataType * data_out) {
+    // this is the splits, right now it is hard coded to split along the z axis
+    int num_io_parts = dc::get_number_of_io_partitions();
+    int ylines = 1;
+    int xlines = 1;
+    int zlines = num_io_parts;
+    int channellines = 1;
+
+    // todo: when taking care of the odd case this cant be an int
+    int xPerNode = dims[3]/xlines;
+    int yPerNode = dims[2]/ylines;
+    int zPerNode = dims[1]/zlines;
+    int cPerNode = dims[0]/channellines;
+    // offset in each dimension
+    hsize_t offset[4];
+    // how many times the pattern should repeat in the hyperslab
+    hsize_t count[4] = {1,1,1,1};
+    // local dimensions aka the dimensions of the slab we will read in
+    hsize_t dims_local[4] = {cPerNode, zPerNode, yPerNode, xPerNode};
+
+    // necessary for the hdf5 lib
+    hid_t memspace = H5Screate_simple(4, dims_local, NULL);
+    int spatial_offset = rank%num_io_parts
+
+    hsize_t offset[4] = {0, zPerNode*spatial_offset, 0, 0};
+    
+    // from an explanation of the hdf5 select_hyperslab:
+    // start -> a starting location for the hyperslab
+    // stride -> the number of elements to separate each element or block to be selected
+    // count -> the number of elemenets or blocks to select along each dimension
+    // block -> the size of the block selected from the dataspace 
+    //hsize_t status;
+
+    //todo add error checking
+    H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset, NULL, count, dims_local);
+    H5Dread(h_data, H5T_NATIVE_SHORT, memspace, filespace, H5P_DEFAULT, data_out);
+  }
+
+  void hdf5_reader::load() {
+    lbann_comm* l_comm = get_comm();
+    const El::mpi::Comm & w_comm = l_comm->get_world_comm();
+    MPI_Comm mpi_comm = w_comm.GetMPIComm();
+    int world_rank = get_rank_in_world();
+    int color = world_rank/dc::get_number_of_io_partitions(); 
+    MPI_Comm_split(mpi_comm, color, world_rank, &m_comm);
+    m_shuffled_indices.clear();
+    m_shuffled_indices.resize(m_file_paths.size());
+    std::iota(m_shuffled_indices.begin(), m_shuffled_indices.end(), 0);
+    int nprocs;
+    MPI_Comm_size(MPI_COMM_WORLD, &nprocs);
+    if ((nprocs%dc::get_number_of_io_partitions()) !=0) {
+      std::cerr<<"nprocs should be divisible by num of io partitions otherwise this wont work \n";
+    }
+    select_subset_of_data();
+  }
+  bool hdf5_reader::fetch_label(Mat& Y, int data_id, int mb_idx) {
+    return true;
+  }
+  bool hdf5_reader::fetch_datum(Mat& X, int data_id, int mb_idx) {
+    prof_region_begin("fetch_datum", prof_colors[0], false); 
+    int world_rank = get_rank_in_world();
+
+    auto file = m_file_paths[data_id];
+
+    hid_t fapl_id = H5Pcreate(H5P_FILE_ACCESS);
+    H5Pset_fapl_mpio(fapl_id, m_comm, MPI_INFO_NULL);
+    hid_t dxpl_id = H5Pcreate(H5P_DATASET_XFER);
+    H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE); 
+    hid_t h_file = H5Fopen(file.c_str(), H5F_ACC_RDONLY, fapl_id);
+    
+    if (h_file < 0) {
+      throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) + 
+          " hdf5_reader::load() - can't open file : " + file);
+    }
+
+    // load in dataset
+    hid_t h_data =  H5Dopen(h_file, HDF5_KEY_DATA.c_str(), dxpl_id);
+    hid_t filespace = H5Dget_space(h_data);
+    //get the number of dimesnionse from the dataset
+    int rank1 = H5Sget_simple_extent_ndims(filespace);
+    hsize_t dims[rank1];
+    // read in what the dimensions are
+    H5Sget_simple_extent_dims(filespace, dims, NULL);
+
+    if (h_data < 0) {
+      throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
+          " hdf5_reader::load() - can't find hdf5 key : " + HDF5_KEY_DATA);
+    }
+
+    //TODO: add the int 16 stuff
+    // check if mb_idx needs to be changed to not be hard coded
+    //int adj_mb_idx = mb_idx+(world_rank%dc::get_number_of_io_partitions());
+    Mat X_v = El::View(X, El::IR(0,X.Height()), El::IR(mb_idx, adj_mb_idx+1));
+
+    DataType *dest = X_v.Buffer();
+    read_hdf5(h_data, filespace, world_rank, HDF5_KEY_DATA, dims, dest);
+    //close data set
+    H5Dclose(h_data);
+    if (m_has_responses) {
+      h_data = H5Dopen(h_file, HDF5_KEY_RESPONSES.c_str(), H5P_DEFAULT);
+      H5Dread(h_data, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, m_all_responses);
+      H5Dclose(h_data);
+    }
+    H5Fclose(h_file);
+  
+    //TODO do i need this?
+    // not if I pass a ref to X I dont think
+    //this should be equal to num_nuerons/LBANN_NUM_IO_PARTITIONS
+    //unsigned long int pixelcount = m_image_width*m_image_height*m_image_depth*m_image_num_channels;
+    // #ifdef LBANN_DISTCONV_COSMOFLOW_KEEP_INT16
+    //    std::memcpy(dest,data, sizeof(short)*pixelcount);
+    // #else
+    //    LBANN_OMP_PARALLEL_FOR
+    //       for(int p = 0; p<pixelcount; p++) {
+    //TODO what is m_scaling_factor_int16
+    //           dest[p] = tmp[p] * m_scaling_factor_int16;
+    // mash this with above
+    //X.Set(p, mb_idx,*tmp++);
+    //       }
+    // #endif
+    //auto pixel_col = X(El::IR(0, X.Height()), El::IR(mb_idx, mb_idx+1));
+    //std::vector<size_t> dims = {
+    //  1ull,
+    //  static_cast<size_t>(m_image_height),
+    //  static_cast<size_t>(m_image_width)};
+    //m_transform_pipeline.apply(pixel_col, dims);
+    prof_region_end("fetch_datum", false);
+    return true;
+  }
+  //get from a cached response
+  bool hdf5_reader::fetch_response(Mat& Y, int data_id, int mb_idx) {
+    prof_region_begin("fetch_response", prof_colors[0], false);
+    Mat Y_v = El::View(Y, El::IR(0, Y.Height()), El::IR(mb_idx, mb_idx+1));
+    //TODO: possibly 4 tho, python tells me its float64
+    std::memcpy(Y_v.Buffer(), &m_all_responses,
+       m_num_responses_features*4);
+    prof_region_end("fetch_response", false);
+    return true;
+  } 
+
+};
+

--- a/src/data_readers/data_reader_hdf5.cpp
+++ b/src/data_readers/data_reader_hdf5.cpp
@@ -33,6 +33,8 @@
 #include <iostream>
 #include <cstring>
 #include "lbann/utils/distconv.hpp"
+#include "conduit/conduit_relay.hpp"
+#include "conduit/conduit_relay_io_hdf5.hpp"
 
 namespace {
 inline hid_t check_hdf5(hid_t hid, const char *file, int line) {
@@ -54,7 +56,43 @@ namespace lbann {
   hdf5_reader::hdf5_reader(const bool shuffle)
     : generic_data_reader(shuffle) {}
 
-  void hdf5_reader::read_hdf5(hsize_t h_data, hsize_t filespace, int rank, std::string key, hsize_t* dims, DataType * data_out) {
+hdf5_reader::hdf5_reader(const hdf5_reader& rhs)  : generic_data_reader(rhs) {
+  copy_members(rhs);
+}
+
+hdf5_reader& hdf5_reader::operator=(const hdf5_reader& rhs) {
+  // check for self-assignment
+  if (this == &rhs) {
+    return (*this);
+  }
+  generic_data_reader::operator=(rhs);
+  copy_members(rhs);
+  return (*this);
+}
+
+
+void hdf5_reader::copy_members(const hdf5_reader &rhs) {
+  if(rhs.m_data_store != nullptr) {
+      m_data_store = new data_store_conduit(rhs.get_data_store());
+  }
+  m_data_store->set_data_reader_ptr(this);
+
+  m_has_labels = rhs.m_has_labels;
+  m_has_responses = rhs.m_has_responses;
+  m_num_features = rhs.m_num_features;
+  m_num_response_features = rhs.m_num_response_features;
+  m_data_dims = rhs.m_data_dims;
+  m_comm = rhs.m_comm;
+  m_data_dims = rhs.m_data_dims;
+  m_scaling_factor_int16 = rhs.m_scaling_factor_int16;
+  m_file_paths = rhs.m_file_paths;
+
+  for(size_t i = 0; i < 4 /*rhs.m_all_responses.size()*/; i++) {
+    m_all_responses[i] = rhs.m_all_responses[i];
+  }
+}
+
+  void hdf5_reader::read_hdf5_hyperslab(hsize_t h_data, hsize_t filespace, int rank, std::string key, hsize_t* dims, conduit::Node& sample) {
     // this is the splits, right now it is hard coded to split along the z axis
     int num_io_parts = dc::get_number_of_io_partitions();
     int ylines = 1;
@@ -86,13 +124,73 @@ namespace lbann {
 
     //todo add error checking
     H5Sselect_hyperslab(filespace, H5S_SELECT_SET, offset, NULL, count, dims_local);
-    H5Dread(h_data, H5T_NATIVE_SHORT, memspace, filespace, H5P_DEFAULT, data_out);
+    sample.set(conduit::DataType::uint16(xPerNode * yPerNode * zPerNode * cPerNode));
+
+    unsigned short* buf = sample.value();
+    H5Dread(h_data, H5T_NATIVE_SHORT, memspace, filespace, H5P_DEFAULT, buf);
+  }
+
+  void hdf5_reader::read_hdf5_sample(int data_id, conduit::Node& sample) {
+    //int world_rank = get_rank_in_world();
+    int world_rank = dc::get_input_rank(*get_comm()); // Should probably be trainer rank
+    auto file = m_file_paths[data_id];
+    hid_t h_file = H5Fopen(file.c_str(), H5F_ACC_RDONLY, m_fapl);
+
+#if 0
+    dc::MPIPrintStreamInfo() << "HDF5 file opened: "
+                             << file;
+#endif
+
+    if (h_file < 0) {
+      throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
+                            " hdf5_reader::load() - can't open file : " + file);
+    }
+
+    // load in dataset
+    hid_t h_data = CHECK_HDF5(
+                              H5Dopen(h_file, HDF5_KEY_DATA.c_str(), H5P_DEFAULT));
+    hid_t filespace = CHECK_HDF5(H5Dget_space(h_data));
+    //get the number of dimesnionse from the dataset
+    int rank1 = H5Sget_simple_extent_ndims(filespace);
+    hsize_t dims[rank1];
+    // read in what the dimensions are
+    CHECK_HDF5(H5Sget_simple_extent_dims(filespace, dims, NULL));
+
+    if (h_data < 0) {
+      throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
+                            " hdf5_reader::load() - can't find hdf5 key : " + HDF5_KEY_DATA);
+    }
+
+    const std::string conduit_obj = LBANN_DATA_ID_STR(data_id);
+    conduit::Node slab;
+    read_hdf5_hyperslab(h_data, filespace, world_rank, HDF5_KEY_DATA, dims, slab);
+    sample[conduit_obj+"/slab"] = slab;
+    //close data set
+    H5Dclose(h_data);
+
+    if (m_has_responses) {
+      h_data = H5Dopen(h_file, HDF5_KEY_RESPONSES.c_str(), H5P_DEFAULT);
+      H5Dread(h_data, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, m_all_responses);
+      // conduit::Node work;
+      // conduit::relay::io::hdf5_read(h_data, HDF5_KEY_RESPONSES.c_str(), work);
+      //      node[conduit_obj+"/responses"].set(conduit::DataType::c_float(4));
+      sample[conduit_obj+"/responses"].set(m_all_responses, 4);
+      H5Dclose(h_data);
+    }
+    H5Fclose(h_file);
+    return;
   }
 
   void hdf5_reader::load() {
     lbann_comm* l_comm = get_comm();
+    if(dc::get_rank_stride() != 1) {
+      LBANN_ERROR("HDF5 MPI-IO data reader requires DistConv rank stride = 1");
+    }
+    // const El::mpi::Comm & w_comm = l_comm->get_world_comm();
+    // MPI_Comm mpi_comm = w_comm.GetMPIComm();
+    // int world_rank = get_rank_in_world();
     MPI_Comm mpi_comm = dc::get_input_comm(*l_comm);
-    int world_rank = dc::get_input_rank(*l_comm);
+    int world_rank = dc::get_input_rank(*l_comm); // Should probably be trainer rank
     int color = world_rank/dc::get_number_of_io_partitions();
     MPI_Comm_split(mpi_comm, color, world_rank, &m_comm);
     m_shuffled_indices.clear();
@@ -108,6 +206,7 @@ namespace lbann {
                                      m_data_dims.end(),
                                      (size_t) 1,
                                      std::multiplies<size_t>());
+
 #ifdef DATA_READER_HDF5_USE_MPI_IO
     m_fapl = H5Pcreate(H5P_FILE_ACCESS);
     CHECK_HDF5(H5Pset_fapl_mpio(m_fapl, m_comm, MPI_INFO_NULL));
@@ -117,6 +216,28 @@ namespace lbann {
     m_fapl = H5P_DEFAULT;
     m_dxpl = H5P_DEFAULT;
 #endif
+    std::vector<int> local_list_sizes;
+    options *opts = options::get();
+    if (opts->get_bool("preload_data_store")) {
+      LBANN_ERROR("preload_data_store not supported on HDF5 data reader");
+#if 0
+      int np = l_comm->get_procs_per_trainer();
+      int base_files_per_rank = m_shuffled_indices.size() / np;
+      int extra = m_shuffled_indices.size() - (base_files_per_rank*np);
+      if (extra > np) {
+        LBANN_ERROR("extra > np");
+      }
+      local_list_sizes.resize(np, 0);
+      for (int j=0; j<np; j++) {
+        local_list_sizes[j] = base_files_per_rank;
+        if (j < extra) {
+          local_list_sizes[j] += 1;
+        }
+      }
+#endif
+    }
+    instantiate_data_store(local_list_sizes);
+
     select_subset_of_data();
   }
   bool hdf5_reader::fetch_label(Mat& Y, int data_id, int mb_idx) {
@@ -124,76 +245,32 @@ namespace lbann {
   }
   bool hdf5_reader::fetch_datum(Mat& X, int data_id, int mb_idx) {
     prof_region_begin("fetch_datum", prof_colors[0], false);
-    int world_rank = dc::get_input_rank(*get_comm());
-
-    auto file = m_file_paths[data_id];
-    hid_t h_file = H5Fopen(file.c_str(), H5F_ACC_RDONLY, m_fapl);
-
-#if 1
-    dc::MPIPrintStreamInfo() << "HDF5 file opened: "
-                             << file;
-#endif
-
-    if (h_file < 0) {
-      throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-          " hdf5_reader::load() - can't open file : " + file);
-    }
-
-    // load in dataset
-    hid_t h_data = CHECK_HDF5(
-        H5Dopen(h_file, HDF5_KEY_DATA.c_str(), H5P_DEFAULT));
-    hid_t filespace = CHECK_HDF5(H5Dget_space(h_data));
-    //get the number of dimesnionse from the dataset
-    int rank1 = H5Sget_simple_extent_ndims(filespace);
-    hsize_t dims[rank1];
-    // read in what the dimensions are
-    CHECK_HDF5(H5Sget_simple_extent_dims(filespace, dims, NULL));
-
-    if (h_data < 0) {
-      throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
-          " hdf5_reader::load() - can't find hdf5 key : " + HDF5_KEY_DATA);
-    }
 
     // In the Cosmoflow case, each minibatch should have only one
     // sample per rank.
     assert_eq(X.Width(), 1);
     // Assuming 512^3 samples
     assert_eq(X.Height(),
-              512 * 512 * 512 * 4 / dc::get_number_of_io_partitions()
+               512 * 512 * 512 * 4 / dc::get_number_of_io_partitions()
               / (sizeof(DataType) / sizeof(short)));
 
-    DataType *dest = X.Buffer();
-    read_hdf5(h_data, filespace, world_rank, HDF5_KEY_DATA, dims, dest);
-    //close data set
-    H5Dclose(h_data);
-    if (m_has_responses) {
-      h_data = H5Dopen(h_file, HDF5_KEY_RESPONSES.c_str(), H5P_DEFAULT);
-      H5Dread(h_data, H5T_NATIVE_FLOAT, H5S_ALL, H5S_ALL, H5P_DEFAULT, m_all_responses);
-      H5Dclose(h_data);
+    // Create a node to hold all of the data
+    conduit::Node node;
+    if (data_store_active()) {
+      const conduit::Node& ds_node = m_data_store->get_conduit_node(data_id);
+      node.set_external(ds_node);
+    }else {
+      read_hdf5_sample(data_id, node);
+      if (priming_data_store()) {
+        // Once the node has been populated save it in the data store
+        m_data_store->set_conduit_node(data_id, node);
+      }
     }
-    H5Fclose(h_file);
+    const std::string conduit_obj = LBANN_DATA_ID_STR(data_id);
+    conduit::Node slab = node[conduit_obj+"/slab"];
+    unsigned short *data = slab.value();
+    std::memcpy(X.Buffer(), data, slab.dtype().number_of_elements()*slab.dtype().element_bytes());
 
-    //TODO do i need this?
-    // not if I pass a ref to X I dont think
-    //this should be equal to num_nuerons/LBANN_NUM_IO_PARTITIONS
-    //unsigned long int pixelcount = m_image_width*m_image_height*m_image_depth*m_image_num_channels;
-    // #ifdef LBANN_DISTCONV_COSMOFLOW_KEEP_INT16
-    //    std::memcpy(dest,data, sizeof(short)*pixelcount);
-    // #else
-    //    LBANN_OMP_PARALLEL_FOR
-    //       for(int p = 0; p<pixelcount; p++) {
-    //TODO what is m_scaling_factor_int16
-    //           dest[p] = tmp[p] * m_scaling_factor_int16;
-    // mash this with above
-    //X.Set(p, mb_idx,*tmp++);
-    //       }
-    // #endif
-    //auto pixel_col = X(El::IR(0, X.Height()), El::IR(mb_idx, mb_idx+1));
-    //std::vector<size_t> dims = {
-    //  1ull,
-    //  static_cast<size_t>(m_image_height),
-    //  static_cast<size_t>(m_image_width)};
-    //m_transform_pipeline.apply(pixel_col, dims);
     prof_region_end("fetch_datum", false);
     return true;
   }
@@ -201,8 +278,20 @@ namespace lbann {
   bool hdf5_reader::fetch_response(Mat& Y, int data_id, int mb_idx) {
     prof_region_begin("fetch_response", prof_colors[0], false);
     assert_eq(Y.Height(), 4);
-    std::memcpy(Y.Buffer(), &m_all_responses,
+    float *buf;
+    // Create a node to hold all of the data
+    conduit::Node node;
+    if (data_store_active()) {
+      const conduit::Node& ds_node = m_data_store->get_conduit_node(data_id);
+      node.set_external(ds_node);
+      const std::string conduit_obj = LBANN_DATA_ID_STR(data_id);
+      buf = node[conduit_obj+"/responses"].value();
+    }else {
+      buf = m_all_responses;
+    }
+    std::memcpy(Y.Buffer(), buf,
                 m_num_response_features*sizeof(DataType));
+
     prof_region_end("fetch_response", false);
     return true;
   }

--- a/src/data_readers/data_reader_hdf5.cpp
+++ b/src/data_readers/data_reader_hdf5.cpp
@@ -91,9 +91,8 @@ namespace lbann {
 
   void hdf5_reader::load() {
     lbann_comm* l_comm = get_comm();
-    const El::mpi::Comm & w_comm = l_comm->get_world_comm();
-    MPI_Comm mpi_comm = w_comm.GetMPIComm();
-    int world_rank = get_rank_in_world();
+    MPI_Comm mpi_comm = dc::get_input_comm(*l_comm);
+    int world_rank = dc::get_input_rank(*l_comm);
     int color = world_rank/dc::get_number_of_io_partitions();
     MPI_Comm_split(mpi_comm, color, world_rank, &m_comm);
     m_shuffled_indices.clear();
@@ -116,7 +115,7 @@ namespace lbann {
   }
   bool hdf5_reader::fetch_datum(Mat& X, int data_id, int mb_idx) {
     prof_region_begin("fetch_datum", prof_colors[0], false);
-    int world_rank = get_rank_in_world();
+    int world_rank = dc::get_input_rank(*get_comm());
 
     auto file = m_file_paths[data_id];
 

--- a/src/data_readers/data_reader_hdf5.cpp
+++ b/src/data_readers/data_reader_hdf5.cpp
@@ -62,12 +62,12 @@ namespace lbann {
     int spatial_offset = rank%num_io_parts;
 
     hsize_t offset[4] = {0, zPerNode*spatial_offset, 0, 0};
-    
+
     // from an explanation of the hdf5 select_hyperslab:
     // start -> a starting location for the hyperslab
     // stride -> the number of elements to separate each element or block to be selected
     // count -> the number of elemenets or blocks to select along each dimension
-    // block -> the size of the block selected from the dataspace 
+    // block -> the size of the block selected from the dataspace
     //hsize_t status;
 
     //todo add error checking
@@ -80,7 +80,7 @@ namespace lbann {
     const El::mpi::Comm & w_comm = l_comm->get_world_comm();
     MPI_Comm mpi_comm = w_comm.GetMPIComm();
     int world_rank = get_rank_in_world();
-    int color = world_rank/dc::get_number_of_io_partitions(); 
+    int color = world_rank/dc::get_number_of_io_partitions();
     MPI_Comm_split(mpi_comm, color, world_rank, &m_comm);
     m_shuffled_indices.clear();
     m_shuffled_indices.resize(m_file_paths.size());
@@ -96,7 +96,7 @@ namespace lbann {
     return true;
   }
   bool hdf5_reader::fetch_datum(Mat& X, int data_id, int mb_idx) {
-    prof_region_begin("fetch_datum", prof_colors[0], false); 
+    prof_region_begin("fetch_datum", prof_colors[0], false);
     int world_rank = get_rank_in_world();
 
     auto file = m_file_paths[data_id];
@@ -104,11 +104,11 @@ namespace lbann {
     hid_t fapl_id = H5Pcreate(H5P_FILE_ACCESS);
     H5Pset_fapl_mpio(fapl_id, m_comm, MPI_INFO_NULL);
     hid_t dxpl_id = H5Pcreate(H5P_DATASET_XFER);
-    H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE); 
+    H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE);
     hid_t h_file = H5Fopen(file.c_str(), H5F_ACC_RDONLY, fapl_id);
-    
+
     if (h_file < 0) {
-      throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) + 
+      throw lbann_exception(std::string{} + __FILE__ + " " + std::to_string(__LINE__) +
           " hdf5_reader::load() - can't open file : " + file);
     }
 
@@ -141,7 +141,7 @@ namespace lbann {
       H5Dclose(h_data);
     }
     H5Fclose(h_file);
-  
+
     //TODO do i need this?
     // not if I pass a ref to X I dont think
     //this should be equal to num_nuerons/LBANN_NUM_IO_PARTITIONS
@@ -175,7 +175,6 @@ namespace lbann {
        m_num_responses_features*4);
     prof_region_end("fetch_response", false);
     return true;
-  } 
+  }
 
 };
-

--- a/src/data_readers/data_reader_hdf5.cpp
+++ b/src/data_readers/data_reader_hdf5.cpp
@@ -127,7 +127,7 @@ void hdf5_reader::copy_members(const hdf5_reader &rhs) {
     sample.set(conduit::DataType::uint16(xPerNode * yPerNode * zPerNode * cPerNode));
 
     unsigned short* buf = sample.value();
-    H5Dread(h_data, H5T_NATIVE_SHORT, memspace, filespace, H5P_DEFAULT, buf);
+    H5Dread(h_data, H5T_NATIVE_SHORT, memspace, filespace, m_dxpl, buf);
   }
 
   void hdf5_reader::read_hdf5_sample(int data_id, conduit::Node& sample) {
@@ -201,11 +201,13 @@ void hdf5_reader::copy_members(const hdf5_reader &rhs) {
                                      (size_t) 1,
                                      std::multiplies<size_t>());
 
+#define DATA_READER_HDF5_USE_MPI_IO
 #ifdef DATA_READER_HDF5_USE_MPI_IO
+    std::cout << "data_reader_hdf5 is compiled with MPI-IO enabled" << std::endl;
     m_fapl = H5Pcreate(H5P_FILE_ACCESS);
     CHECK_HDF5(H5Pset_fapl_mpio(m_fapl, m_comm, MPI_INFO_NULL));
     m_dxpl = H5Pcreate(H5P_DATASET_XFER);
-    CHECK_HDF5(H5Pset_dxpl_mpio(m_dxpl, H5FD_MPIO_COLLECTIVE));
+    CHECK_HDF5(H5Pset_dxpl_mpio(m_dxpl, H5FD_MPIO_INDEPENDENT));  // H5FD_MPIO_COLLECTIVE
 #else
     m_fapl = H5P_DEFAULT;
     m_dxpl = H5P_DEFAULT;

--- a/src/data_readers/data_reader_hdf5.cpp
+++ b/src/data_readers/data_reader_hdf5.cpp
@@ -131,8 +131,8 @@ void hdf5_reader::copy_members(const hdf5_reader &rhs) {
   }
 
   void hdf5_reader::read_hdf5_sample(int data_id, conduit::Node& sample) {
-    //int world_rank = get_rank_in_world();
-    int world_rank = dc::get_input_rank(*get_comm()); // Should probably be trainer rank
+    int world_rank = get_rank_in_world();
+    //int world_rank = dc::get_input_rank(*get_comm()); // Should probably be trainer rank
     auto file = m_file_paths[data_id];
     hid_t h_file = H5Fopen(file.c_str(), H5F_ACC_RDONLY, m_fapl);
 
@@ -186,11 +186,11 @@ void hdf5_reader::copy_members(const hdf5_reader &rhs) {
     if(dc::get_rank_stride() != 1) {
       LBANN_ERROR("HDF5 MPI-IO data reader requires DistConv rank stride = 1");
     }
-    // const El::mpi::Comm & w_comm = l_comm->get_world_comm();
-    // MPI_Comm mpi_comm = w_comm.GetMPIComm();
-    // int world_rank = get_rank_in_world();
-    MPI_Comm mpi_comm = dc::get_input_comm(*l_comm);
-    int world_rank = dc::get_input_rank(*l_comm); // Should probably be trainer rank
+    const El::mpi::Comm & w_comm = l_comm->get_world_comm();
+    MPI_Comm mpi_comm = w_comm.GetMPIComm();
+    int world_rank = get_rank_in_world();
+    // MPI_Comm mpi_comm = dc::get_input_comm(*l_comm);
+    // int world_rank = dc::get_input_rank(*l_comm); // Should probably be trainer rank
     int color = world_rank/dc::get_number_of_io_partitions();
     MPI_Comm_split(mpi_comm, color, world_rank, &m_comm);
     m_shuffled_indices.clear();

--- a/src/data_readers/data_reader_hdf5.cpp
+++ b/src/data_readers/data_reader_hdf5.cpp
@@ -267,7 +267,8 @@ void hdf5_reader::copy_members(const hdf5_reader &rhs) {
       }
     }
     const std::string conduit_obj = LBANN_DATA_ID_STR(data_id);
-    conduit::Node slab = node[conduit_obj+"/slab"];
+    conduit::Node slab;
+    slab.set_external(node[conduit_obj+"/slab"]);
     unsigned short *data = slab.value();
     std::memcpy(X.Buffer(), data, slab.dtype().number_of_elements()*slab.dtype().element_bytes());
 

--- a/src/data_readers/data_reader_hdf5.cpp
+++ b/src/data_readers/data_reader_hdf5.cpp
@@ -48,13 +48,10 @@ namespace lbann {
     int zlines = num_io_parts;
     int channellines = 1;
 
-    // todo: when taking care of the odd case this cant be an int
-    int xPerNode = dims[3]/xlines;
-    int yPerNode = dims[2]/ylines;
-    int zPerNode = dims[1]/zlines;
-    int cPerNode = dims[0]/channellines;
-    // offset in each dimension
-    hsize_t offset[4];
+    hsize_t xPerNode = dims[3]/xlines;
+    hsize_t yPerNode = dims[2]/ylines;
+    hsize_t zPerNode = dims[1]/zlines;
+    hsize_t cPerNode = dims[0]/channellines;
     // how many times the pattern should repeat in the hyperslab
     hsize_t count[4] = {1,1,1,1};
     // local dimensions aka the dimensions of the slab we will read in

--- a/src/data_readers/data_reader_hdf5.cpp
+++ b/src/data_readers/data_reader_hdf5.cpp
@@ -131,8 +131,7 @@ void hdf5_reader::copy_members(const hdf5_reader &rhs) {
   }
 
   void hdf5_reader::read_hdf5_sample(int data_id, conduit::Node& sample) {
-    int world_rank = get_rank_in_world();
-    //int world_rank = dc::get_input_rank(*get_comm()); // Should probably be trainer rank
+    int world_rank = dc::get_input_rank(*get_comm()); // Should probably be trainer rank
     auto file = m_file_paths[data_id];
     hid_t h_file = H5Fopen(file.c_str(), H5F_ACC_RDONLY, m_fapl);
 
@@ -162,9 +161,7 @@ void hdf5_reader::copy_members(const hdf5_reader &rhs) {
     }
 
     const std::string conduit_obj = LBANN_DATA_ID_STR(data_id);
-    conduit::Node slab;
-    read_hdf5_hyperslab(h_data, filespace, world_rank, HDF5_KEY_DATA, dims, slab);
-    sample[conduit_obj+"/slab"] = slab;
+    read_hdf5_hyperslab(h_data, filespace, world_rank, HDF5_KEY_DATA, dims, sample[conduit_obj+"/slab"]);
     //close data set
     H5Dclose(h_data);
 
@@ -186,11 +183,8 @@ void hdf5_reader::copy_members(const hdf5_reader &rhs) {
     if(dc::get_rank_stride() != 1) {
       LBANN_ERROR("HDF5 MPI-IO data reader requires DistConv rank stride = 1");
     }
-    const El::mpi::Comm & w_comm = l_comm->get_world_comm();
-    MPI_Comm mpi_comm = w_comm.GetMPIComm();
-    int world_rank = get_rank_in_world();
-    // MPI_Comm mpi_comm = dc::get_input_comm(*l_comm);
-    // int world_rank = dc::get_input_rank(*l_comm); // Should probably be trainer rank
+    MPI_Comm mpi_comm = dc::get_input_comm(*l_comm);
+    int world_rank = dc::get_input_rank(*l_comm); // Should probably be trainer rank
     int color = world_rank/dc::get_number_of_io_partitions();
     MPI_Comm_split(mpi_comm, color, world_rank, &m_comm);
     m_shuffled_indices.clear();

--- a/src/data_readers/data_reader_hdf5.cpp
+++ b/src/data_readers/data_reader_hdf5.cpp
@@ -62,7 +62,7 @@ namespace lbann {
 
     // necessary for the hdf5 lib
     hid_t memspace = H5Screate_simple(4, dims_local, NULL);
-    int spatial_offset = rank%num_io_parts
+    int spatial_offset = rank%num_io_parts;
 
     hsize_t offset[4] = {0, zPerNode*spatial_offset, 0, 0};
     

--- a/src/data_store/data_store_conduit.cpp
+++ b/src/data_store/data_store_conduit.cpp
@@ -32,6 +32,7 @@
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/options.hpp"
 #include "lbann/utils/timer.hpp"
+#include "lbann/utils/distconv.hpp"
 #include <unordered_set>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -52,10 +53,15 @@ data_store_conduit::data_store_conduit(
     LBANN_ERROR(" m_comm is nullptr");
   }
 
+  int num_io_parts = dc::get_number_of_io_partitions();
+
   m_world_master = m_comm->am_world_master();
   m_trainer_master = m_comm->am_trainer_master();
-  m_rank_in_trainer = m_comm->get_rank_in_trainer();
-  m_np_in_trainer = m_comm->get_procs_per_trainer();
+  m_rank_in_trainer = (m_comm->get_rank_in_trainer());
+  m_partition_in_trainer = m_rank_in_trainer/num_io_parts; // needs a better name  which group you are in
+  m_offset_in_partition = m_rank_in_trainer%num_io_parts;
+  m_np_in_trainer = (m_comm->get_procs_per_trainer());
+  m_num_partitions_in_trainer = m_np_in_trainer/num_io_parts; // rename this m_num_io_groups_in_trainer
 
   options *opts = options::get();
   m_super_node = opts->get_bool("super_node");
@@ -120,8 +126,8 @@ data_store_conduit& data_store_conduit::operator=(const data_store_conduit& rhs)
   return (*this);
 }
 
-void data_store_conduit::set_data_reader_ptr(generic_data_reader *reader) { 
-  m_reader = reader; 
+void data_store_conduit::set_data_reader_ptr(generic_data_reader *reader) {
+  m_reader = reader;
   if (options::get()->get_bool("debug")) {
     std::stringstream ss;
     ss << "debug_" << m_reader->get_role() << "." << m_comm->get_rank_in_world();
@@ -190,9 +196,10 @@ void data_store_conduit::copy_members(const data_store_conduit& rhs, const std::
       }
 
       /// Removed migrated nodes from the original data store's owner list
-      if(rhs.m_owner.find(i) != rhs.m_owner.end()) {
-        m_owner[i] = rhs.m_owner[i];
-        rhs.m_owner.erase(i);
+      auto key = std::make_pair(i, m_offset_in_partition);
+      if(rhs.m_owner.find(key) != rhs.m_owner.end()) {
+        m_owner[key] = rhs.m_owner[key];
+        rhs.m_owner.erase(key);
       }
     }
   }
@@ -463,7 +470,7 @@ void data_store_conduit::set_conduit_node(int data_id, conduit::Node &node, bool
 
   #if 0
   else if (m_owner[data_id] != m_rank_in_trainer) {
-    LBANN_ERROR("set_conduit_node error for data id: ", data_id, " m_owner: ", 
+    LBANN_ERROR("set_conduit_node error for data id: ", data_id, " m_owner: ",
                  m_owner[data_id], " me: ", m_rank_in_trainer,
                  "; data reader role: ", m_reader->get_role());
   }
@@ -471,7 +478,11 @@ void data_store_conduit::set_conduit_node(int data_id, conduit::Node &node, bool
 
   else if (! m_super_node) {
     m_mutex.lock();
-    m_owner[data_id] = m_rank_in_trainer;
+    if(m_output) {
+      (*m_output) << "set_conduit_node : rank_in_trainer=" << m_rank_in_trainer << " and partition_in_trainer=" << m_partition_in_trainer << " offset in partition=" << m_offset_in_partition << " with num_partitions=" << m_num_partitions_in_trainer << std::endl;
+    }
+    auto key = std::make_pair(data_id, m_offset_in_partition);
+    m_owner[key] = m_rank_in_trainer;
     build_node_for_sending(node, m_data[data_id]);
     error_check_compacted_node(m_data[data_id], data_id);
     m_sample_sizes[data_id] = m_data[data_id].total_bytes_compact();
@@ -480,7 +491,8 @@ void data_store_conduit::set_conduit_node(int data_id, conduit::Node &node, bool
 
   else {
     m_mutex.lock();
-    m_owner[data_id] = m_rank_in_trainer;
+    auto key = std::make_pair(data_id, m_offset_in_partition);
+    m_owner[key] = m_rank_in_trainer;
     m_data[data_id] = node;
     m_mutex.unlock();
   }
@@ -707,8 +719,10 @@ int data_store_conduit::build_indices_i_will_recv(int current_pos, int mb_size) 
   int k = 0;
   for (int i=current_pos; i< current_pos + mb_size; ++i) {
     auto index = (*m_shuffled_indices)[i];
-    if ((i % m_owner_map_mb_size) % m_np_in_trainer == m_rank_in_trainer) {
-      int owner = m_owner[index];
+    int num_ranks_in_partition = dc::get_number_of_io_partitions();
+    if ((((i % m_owner_map_mb_size) % m_num_partitions_in_trainer) * num_ranks_in_partition + m_offset_in_partition) == m_rank_in_trainer) {
+      auto key = std::make_pair(index, m_offset_in_partition);
+      int owner = m_owner[key];
       m_indices_to_recv[owner].insert(index);
       k++;
     }
@@ -723,16 +737,19 @@ int data_store_conduit::build_indices_i_will_send(int current_pos, int mb_size) 
   if (m_output) {
     (*m_output) << "build_indices_i_will_send; cur pos: " << current_pos << " mb_size: " << mb_size << " m_data.size: " << m_data.size() << "\n";
   }
+
   for (int i = current_pos; i < current_pos + mb_size; i++) {
     auto index = (*m_shuffled_indices)[i];
     /// If this rank owns the index send it to the (i%m_np)'th rank
     if (m_data.find(index) != m_data.end()) {
-      m_indices_to_send[(i % m_owner_map_mb_size) % m_np_in_trainer].insert(index);
+      int num_ranks_in_partition = dc::get_number_of_io_partitions();
+      m_indices_to_send[(((i % m_owner_map_mb_size) % m_num_partitions_in_trainer) * num_ranks_in_partition + m_offset_in_partition)].insert(index);
 
       // Sanity check
-      if (m_owner[index] != m_rank_in_trainer) {
+      auto key = std::make_pair(index, m_offset_in_partition);
+      if (m_owner[key] != m_rank_in_trainer) {
         std::stringstream s;
-        s << "error for i: "<<i<<" index: "<<index<< " m_owner: " << m_owner[index] << " me: " << m_rank_in_trainer;
+        s << "error for i: "<<i<<" index: "<<index<< " m_owner: " << m_owner[key] << " me: " << m_rank_in_trainer;
         LBANN_ERROR(s.str());
       }
       k++;
@@ -751,7 +768,8 @@ void data_store_conduit::build_preloaded_owner_map(const std::vector<int>& per_r
       ++owning_rank;
       per_rank_list_range_start += per_rank_list_size;
     }
-    m_owner[(*m_shuffled_indices)[i]] = owning_rank;
+    auto key = std::make_pair((*m_shuffled_indices)[i], m_offset_in_partition);
+    m_owner[key] = owning_rank;
   }
 }
 
@@ -768,7 +786,8 @@ void data_store_conduit::build_owner_map(int mini_batch_size) {
     /// To compute the owner index first find its position inside of
     /// the mini-batch (mod mini-batch size) and then find how it is
     /// striped across the ranks in the trainer
-    m_owner[index] = (i % m_owner_map_mb_size) % m_np_in_trainer;
+    auto key = std::make_pair(index, m_offset_in_partition);
+    m_owner[key] = (i % m_owner_map_mb_size) % m_np_in_trainer;
   }
 }
 #endif
@@ -808,8 +827,9 @@ void data_store_conduit::purge_unused_samples(const std::vector<int>& indices) {
     if(m_data.find(i) != m_data.end()){
       m_data.erase(i);
     }
-    if(m_owner.find(i) != m_owner.end()) {
-      m_owner.erase(i);
+    auto key = std::make_pair(i, m_offset_in_partition);
+    if(m_owner.find(key) != m_owner.end()) {
+      m_owner.erase(key);
     }
   }
   if (m_output) {
@@ -834,14 +854,15 @@ void data_store_conduit::compact_nodes() {
 }
 
 int data_store_conduit::get_index_owner(int idx) {
-  if (m_owner.find(idx) == m_owner.end()) {
+  auto key = std::make_pair(idx, m_offset_in_partition);
+  if (m_owner.find(key) == m_owner.end()) {
     std::stringstream err;
     err << __FILE__ << " " << __LINE__ << " :: "
         << " idx: " << idx << " was not found in the m_owner map;"
         << " map size: " << m_owner.size();
     throw lbann_exception(err.str());
   }
-  return m_owner[idx];
+  return m_owner[key];
 }
 
 void data_store_conduit::check_mem_capacity(lbann_comm *comm, const std::string sample_list_file, size_t stride, size_t offset) {
@@ -1347,37 +1368,60 @@ void data_store_conduit::exchange_owner_maps() {
     (*m_output) << "\nstarting data_store_conduit::exchange_owner_maps\n\n";
   }
   int my_count = m_owner.size();
+
   std::vector<int> all_counts(m_np_in_trainer);
   m_comm->all_gather(&my_count, 1, all_counts.data(), 1,  m_comm->get_trainer_comm());
 
-  std::vector<size_t> my_sizes(m_owner.size());
+  std::vector<std::pair<size_t,size_t>> nodes_i_own(m_owner.size());
   size_t j = 0;
   for (auto t : m_owner) {
-    my_sizes[j++] = t.first;
+    auto slab_id = std::make_pair(t.first.first, t.first.second);
+    nodes_i_own[j++] = slab_id;
+    if(m_output) {
+      (*m_output) << "I am building the size vector from the owner map for " << t.first.first << "." << t.first.second << " and " << t.second << std::endl;
+    }
   }
 
-  std::vector<size_t> other_sizes;
+  std::vector<std::pair<size_t,size_t>> other_ranks_nodes;
   for (int k=0; k<m_np_in_trainer; k++) {
-    other_sizes.resize(all_counts[k]);
+    other_ranks_nodes.resize(all_counts[k]);
     if (m_rank_in_trainer == k) {
-      m_comm->broadcast<size_t>(k, my_sizes.data(), all_counts[k],  m_comm->get_trainer_comm());
+      m_comm->broadcast<std::pair<size_t,size_t>>(k, nodes_i_own.data(), all_counts[k],  m_comm->get_trainer_comm());
+      if(m_output) {
+        int c = 0;
+        for(auto i : nodes_i_own) {
+          (*m_output) << "k=" << k <<  ": nodes_i_own[" << c << "]=" << i.first << "." << i.second << std::endl;
+          c++;
+        }
+      }
     } else {
-      m_comm->broadcast<size_t>(k, other_sizes.data(), all_counts[k],  m_comm->get_trainer_comm());
-      for (size_t i=0; i<other_sizes.size(); ++i) {
-        if (m_owner.find(other_sizes[i]) != m_owner.end()) {
+      m_comm->broadcast<std::pair<size_t,size_t>>(k, other_ranks_nodes.data(), all_counts[k],  m_comm->get_trainer_comm());
+      if(m_output) {
+        int c = 0;
+        for(auto i : other_ranks_nodes) {
+          (*m_output) << "k=" << k <<  ": other_ranks_nodes[" << c << "]=" << i.first << "." << i.second << std::endl;
+          c++;
+        }
+      }
+      for (size_t i=0; i<other_ranks_nodes.size(); ++i) {
+        auto key = other_ranks_nodes[i];
+        // Check to make sure that I don't own this
+        if (m_owner.find(key) != m_owner.end()) {
 
           if (m_output) {
-            (*m_output) << "data_store_conduit::exchange_owner_maps, duplicate data_id: " << other_sizes[i] << "; k= " << k << "\nm_owner:\n";
-            for (auto t : m_owner) (*m_output) << "data_id: " << t.first << " owner: " << t.second << std::endl;
-            (*m_output) << "\nother_sizes[k]: ";
-            for (auto t : other_sizes) (*m_output) << t << " ";
+            auto slab_id = other_ranks_nodes[i];
+            (*m_output) << "data_store_conduit::exchange_owner_maps, duplicate data_id: " << slab_id.first << "." << slab_id.second  << "; k= " << k << "\nm_owner:\n";
+            for (auto t : m_owner) (*m_output) << "data_id: " << t.first.first << " / " << t.first.second << " owner: " << t.second << std::endl;
+            (*m_output) << "\nother_ranks_nodes[k]: ";
+            for (auto t : other_ranks_nodes) (*m_output) << t.first << "." << t.second << " ";
             (*m_output) << std::endl;
             flush_debug_file();
           }
 
-          LBANN_ERROR("duplicate data_id: ", other_sizes[i], " role: ", m_reader->get_role(), "; m_owner[",other_sizes[i],"] = ", m_owner[other_sizes[i]]);
+          LBANN_ERROR("duplicate data_id: ", other_ranks_nodes[i].first, ".",
+                      other_ranks_nodes[i].second, " role: ", m_reader->get_role(), "; m_owner[",other_ranks_nodes[i].first, ".", other_ranks_nodes[i].second,"] = ", m_owner[key]);
         }
-        m_owner[other_sizes[i]] = k;
+        m_owner[key] = k;
       }
     }
   }
@@ -1390,9 +1434,9 @@ void data_store_conduit::exchange_mini_batch_data(size_t current_pos, size_t mb_
   }
   if (m_reader->at_new_epoch()) {
     if (m_world_master && m_cur_epoch > 0) {
-      std::cout << "time for exchange_mini_batch_data calls: " 
+      std::cout << "time for exchange_mini_batch_data calls: "
                 << m_exchange_time << std::endl
-                << "time for constructing conduit Nodes: " << m_rebuild_time 
+                << "time for constructing conduit Nodes: " << m_rebuild_time
                 << std::endl;
       if (m_super_node) {
         std::cout << "time for constructing super_nodes: " << m_super_node_packaging_time;

--- a/src/io/data_buffers/partitioned_io_buffer.cpp
+++ b/src/io/data_buffers/partitioned_io_buffer.cpp
@@ -27,6 +27,7 @@
 #include "lbann/io/data_buffers/partitioned_io_buffer.hpp"
 #include "lbann/utils/exception.hpp"
 #include "lbann/utils/profiling.hpp"
+#include "lbann/utils/distconv.hpp"
 
 lbann::partitioned_io_buffer::partitioned_io_buffer(lbann_comm *comm, int num_parallel_readers, std::map<execution_mode, generic_data_reader *> data_readers, int num_child_layers)
   : generic_io_buffer(comm, num_parallel_readers, data_readers) {
@@ -348,6 +349,9 @@ void lbann::partitioned_io_buffer::calculate_num_iterations_per_epoch_single_mod
   /// Set the basic parameters for stride and offset of the data reader
   int batch_stride = max_mini_batch_size;
   int base_offset  = m_comm->get_rank_in_trainer();
+#ifdef LBANN_HAS_DISTCONV
+  base_offset /= dc::get_number_of_io_partitions();
+#endif
   /// Set mini-batch size and stride
   data_reader->set_mini_batch_size(max_mini_batch_size);
   data_reader->set_stride_to_next_mini_batch(batch_stride);

--- a/src/io/data_buffers/partitioned_io_buffer.cpp
+++ b/src/io/data_buffers/partitioned_io_buffer.cpp
@@ -108,12 +108,6 @@ int lbann::partitioned_io_buffer::fetch_to_local_matrix(generic_data_reader *dat
   data_buffer *buf = get_data_buffer(mode);
   buf->m_num_samples_fetched = 0;
 
-  dc::MPIPrintStreamInfo()
-      << "m_input_buffers[0]->Height(): " << buf->m_input_buffers[0]->Height()
-      << ", m_input_buffers[0]->Width(): " << buf->m_input_buffers[0]->Width()
-      << ", m_input_buffers[0]->Matrix().Width(): "
-      << buf->m_input_buffers[0]->Matrix().Width();
-
   if (m_comm->get_rank_in_trainer() < num_parallel_readers && (buf->m_input_buffers[0]->Height() != 0 && buf->m_input_buffers[0]->Width() != 0)) {
 #ifndef LBANN_IO_DISABLE_ZEROS
     prof_region_begin("fetch_to_local_matrix_zeros", prof_colors[3], false);
@@ -286,8 +280,6 @@ void lbann::partitioned_io_buffer::calculate_num_iterations_per_epoch_spanning_m
   data_reader->set_mini_batch_size(max_mini_batch_size);
   data_reader->set_stride_to_next_mini_batch(batch_stride);
 #ifdef LBANN_HAS_DISTCONV
-  dc::MPIPrintStreamInfo() << "sample stride: " <<
-      num_parallel_readers_per_model / dc::get_number_of_io_partitions();
   data_reader->set_sample_stride(num_parallel_readers_per_model / dc::get_number_of_io_partitions());
 #else
   data_reader->set_sample_stride(num_parallel_readers_per_model);
@@ -359,12 +351,6 @@ void lbann::partitioned_io_buffer::calculate_num_iterations_per_epoch_spanning_m
 #endif
   }
 
-#ifdef LBANN_HAS_DISTCONV
-  dc::MPIPrintStreamInfo()
-      << "stride_to_last_mini_batch: " << data_reader->get_stride_to_last_mini_batch()
-      << ", stride_to_next_mini_batch: " << data_reader->get_stride_to_next_mini_batch();
-#endif
-
   //  cout << "[" << m_comm->get_rank_in_world() << "] " << m_comm->get_trainer_rank() << " model rank, "<< m_comm->get_rank_in_trainer() << " rank in model, num_whole_mini_batches_per_model " << num_whole_mini_batches_per_model << " parallel_readers_with_extra_mini_batch " << /*parallel_readers_with_extra_mini_batch <<*/ " partial_mini_batch_size=" << per_model_partial_mini_batch_size << " last mini bath size=" << data_reader->get_last_mini_batch_size() << " world_master_remainder_data=" << world_master_remainder_data << " with a last stride of " << data_reader->get_stride_to_last_mini_batch() << " and stride of " << data_reader->get_stride_to_next_mini_batch() << " and there are " << num_parallel_readers_per_model << " parallel readers per model" << " last mini batch offset = " << last_mini_batch_offset <<  " parallel reader with extra minibatch = " << /*parallel_readers_with_extra_mini_batch << */" model bracket = " << (/*parallel_readers_with_extra_mini_batch **/ max_mini_batch_size + per_model_partial_mini_batch_size + world_master_remainder_data) <<" base ofset "<< data_reader->get_base_offset() << " model offset " << data_reader->get_model_offset() <<endl;
 //cout << "[" << m_comm->get_rank_in_world() << "] " << m_comm->get_trainer_rank() << " model rank, "<< m_comm->get_rank_in_trainer() << " rank in model, num_whole_mini_batches_per_model " << num_whole_mini_batches_per_model << " num_whole_mini_batches_per_reader " << num_whole_mini_batches_per_reader << "(m_num_mini_batches_per_reader=" << data_reader->get_num_mini_batches_per_reader() << ") parallel_readers_with_extra_mini_batch " << /*parallel_readers_with_extra_mini_batch <<*/ " partial_mini_batch_size=" << per_model_partial_mini_batch_size << " last mini bath size=" << data_reader->get_last_mini_batch_size() << " world_master_remainder_data=" << world_master_remainder_data << " threshold " << data_reader->get_last_mini_batch_threshold() << " with a last stride of " << data_reader->get_stride_to_last_mini_batch() << " and stride of " << data_reader->get_batch_stride() << " and there are " << num_parallel_readers_per_model << " parallel readers per model" << " last mini batch offset = " << last_mini_batch_offset <<  " parallel reader with extra minibatch = " << /*parallel_readers_with_extra_mini_batch << */" model bracket = " << (/*parallel_readers_with_extra_mini_batch **/ max_mini_batch_size + per_model_partial_mini_batch_size + world_master_remainder_data) <<" base ofset "<< data_reader->get_base_offset() << " model offset " << data_reader->get_model_offset() <<endl;
   return;
@@ -399,8 +385,6 @@ void lbann::partitioned_io_buffer::calculate_num_iterations_per_epoch_single_mod
   data_reader->set_mini_batch_size(max_mini_batch_size);
   data_reader->set_stride_to_next_mini_batch(batch_stride);
 #ifdef LBANN_HAS_DISTCONV
-  dc::MPIPrintStreamInfo() << "sample stride: " <<
-      num_parallel_readers_per_model / dc::get_number_of_io_partitions();
   data_reader->set_sample_stride(num_parallel_readers_per_model / dc::get_number_of_io_partitions());
 #else
   data_reader->set_sample_stride(num_parallel_readers_per_model);

--- a/src/io/data_buffers/partitioned_io_buffer.cpp
+++ b/src/io/data_buffers/partitioned_io_buffer.cpp
@@ -73,6 +73,8 @@ void lbann::partitioned_io_buffer::fp_setup_data(El::Int cur_mini_batch_size, in
 
 void lbann::partitioned_io_buffer::setup_data(El::Int num_neurons, El::Int num_targets, El::Int max_mini_batch_size) {
 #ifdef LBANN_HAS_DISTCONV
+  num_neurons /= dc::get_number_of_io_partitions();
+  num_neurons /= sizeof(DataType) / sizeof(short);
   max_mini_batch_size *= dc::get_number_of_io_partitions();
 #endif
   El::Int local_mini_batch_size = max_mini_batch_size / m_comm->get_procs_per_trainer();

--- a/src/io/data_buffers/partitioned_io_buffer.cpp
+++ b/src/io/data_buffers/partitioned_io_buffer.cpp
@@ -140,10 +140,16 @@ int lbann::partitioned_io_buffer::fetch_to_local_matrix(generic_data_reader *dat
 }
 
 void lbann::partitioned_io_buffer::distribute_from_local_matrix(generic_data_reader *data_reader, execution_mode mode, AbsDistMat& sample, AbsDistMat& response) {
+  prof_region_begin("distribute_from_local_matrix", prof_colors[3], false);
   data_buffer *buf = get_data_buffer(mode);
   Copy(*buf->m_input_buffers[0], sample);
   Copy(*buf->m_input_buffers[1], response);
+#ifdef LBANN_HAS_DISTCONV
+  response.Resize(response.Height(), response.Width() /
+                  dc::get_number_of_io_partitions());
+#endif
   buf->m_num_samples_fetched = 0;
+  prof_region_end("distribute_from_local_matrix", false);
   return;
 }
 

--- a/src/proto/init_image_data_readers.cpp
+++ b/src/proto/init_image_data_readers.cpp
@@ -34,6 +34,7 @@
 #include "lbann/data_readers/data_reader_imagenet.hpp"
 #include "lbann/data_readers/data_reader_mnist.hpp"
 #include "lbann/data_readers/data_reader_multihead_siamese.hpp"
+#include "lbann/data_readers/data_reader_hdf5.hpp"
 
 #include <reader.pb.h>
 

--- a/src/proto/proto_common.cpp
+++ b/src/proto/proto_common.cpp
@@ -221,6 +221,16 @@ void init_data_readers(
       reader_cosmoflow->set_npz_paths(paths);
       reader_cosmoflow->set_scaling_factor_int16(readme.scaling_factor_int16());
       reader = reader_cosmoflow;
+    } else if (name=="cosmoflow_hdf5") {
+      auto* reader_cosmo_hdf5 = new hdf5_reader(shuffle);
+      auto filedir = readme.data_filedir();
+      if(!endsWith(filedir, "/")) {
+        filedir = filedir + "/";
+      } 
+      const auto paths = glob(filedir +readme.data_file_pattern());
+      reader_cosmo_hdf5->set_hdf5_paths(paths);
+      reader_cosmo_hdf5->set_scaling_factor_int16(readme.scaling_factor_int16());
+      reader = reader_cosmo_hdf5; 
     } else if (name == "pilot2_molecular_reader") {
       pilot2_molecular_reader* reader_pilot2_molecular = new pilot2_molecular_reader(readme.num_neighbors(), readme.max_neighborhood(), shuffle);
       reader = reader_pilot2_molecular;

--- a/src/utils/distconv.cpp
+++ b/src/utils/distconv.cpp
@@ -55,6 +55,7 @@ std::string opt_convolution_bwd_filter_algorithm("DEFAULT");
 std::string opt_synthetic_data_reader_randgen("MINSTD");
 int opt_num_pre_generated_synthetic_data = 0;
 bool opt_deterministic = false;
+int opt_num_io_partitions = 1;
 
 void set_options() {
   if (options_set) return;
@@ -101,6 +102,10 @@ void set_options() {
   if (env) {
     opt_deterministic = true;
   }
+  env = getenv("LBANN_NUM_IO_PARTITIONS");
+  if (env) {
+    opt_num_io_partitions = std::atoi(env);
+  }
   options_set = true;
 }
 
@@ -131,6 +136,9 @@ void print_options(std::ostream &os) {
        << std::endl;
     ss << "  deterministic: "
        << opt_deterministic
+       << std::endl;
+    ss << "  num_io_partitions: "
+       << opt_num_io_partitions
        << std::endl;
     os << ss.str();
   }
@@ -337,6 +345,10 @@ int get_number_of_pre_generated_synthetic_data() {
 
 bool is_deterministic() {
   return opt_deterministic;
+}
+
+int get_number_of_io_partitions() {
+  return opt_num_io_partitions;
 }
 
 p2p::P2P &get_p2p() {

--- a/src/utils/distconv.cpp
+++ b/src/utils/distconv.cpp
@@ -56,6 +56,7 @@ std::string opt_synthetic_data_reader_randgen("MINSTD");
 int opt_num_pre_generated_synthetic_data = 0;
 bool opt_deterministic = false;
 int opt_num_io_partitions = 1;
+bool opt_cosmoflow_parallel_io = false;
 
 void set_options() {
   if (options_set) return;
@@ -102,9 +103,13 @@ void set_options() {
   if (env) {
     opt_deterministic = true;
   }
-  env = getenv("LBANN_NUM_IO_PARTITIONS");
+  env = getenv("LBANN_DISTCONV_NUM_IO_PARTITIONS");
   if (env) {
     opt_num_io_partitions = std::atoi(env);
+  }
+  env = getenv("LBANN_DISTCONV_COSMOFLOW_PARALLEL_IO");
+  if (env) {
+    opt_cosmoflow_parallel_io = true;
   }
   options_set = true;
 }
@@ -139,6 +144,9 @@ void print_options(std::ostream &os) {
        << std::endl;
     ss << "  num_io_partitions: "
        << opt_num_io_partitions
+       << std::endl;
+    ss << "  cosmoflow_parallel_io: "
+       << opt_cosmoflow_parallel_io
        << std::endl;
     os << ss.str();
   }
@@ -349,6 +357,10 @@ bool is_deterministic() {
 
 int get_number_of_io_partitions() {
   return opt_num_io_partitions;
+}
+
+bool is_cosmoflow_parallel_io_enabled() {
+  return opt_cosmoflow_parallel_io;
 }
 
 p2p::P2P &get_p2p() {


### PR DESCRIPTION
Added support for placing a slab of a sample's data into the data
store.  Then each partition of data (slab) is manged as if it were a
subsample and exchanges within a fixed offset of nodes.  Also added
support in the data store to record the sample ID and slab ID.