### PR TITLE
Process labels/responses with Distconv

### DIFF
--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -1192,10 +1192,23 @@ class generic_input_layer : public io_layer {
     copy_label_distconv(mb_size);
   }
 
+  // TODO: This is a temporary hack. The label tensor shape should
+  //be set based on the shape set by the data reader, but the data
+  //reader does not provide it. Using the shape shape as the data
+  //tensor works fine for the U-Net model.
+  dc::Shape get_unet_label_shape() const {
+    auto shape = get_output_tensor_shape(0);
+    auto label_size = get_output_tensor_shape(1).reduce_prod();
+    auto num_channels = label_size / shape.reduce_prod();
+    shape[-2] = num_channels;
+    return shape;
+  }
+
   void setup_label_tensors() {
     using namespace dc;
     assert_always(m_copy_labels_dc);
-    const auto tensor_shape = get_output_tensor_shape(1);
+    //const auto tensor_shape = get_output_tensor_shape(1);
+    const auto tensor_shape = get_unet_label_shape();
     const auto sample_dist = Layer::get_hydrogen_matrix_distribution();
     auto local_shape = tensor_shape;
     // calculated by Distconv

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -889,13 +889,6 @@ class generic_input_layer : public io_layer {
       dc::MPIRootPrintStreamInfo() << "Copy label/response data to Distconv as well";
     }
 
-#if 0
-    auto mb_shape = get_output_dims(0);
-    dc::MPIRootPrintStreamInfo() << "Mini-batch shape: "
-                                 << dc::util::tostring(mb_shape.begin(),
-                                                       mb_shape.end());
-#endif
-
     const auto tensor_shape = get_output_tensor_shape();
     const Dist sample_dist = Layer::get_hydrogen_matrix_distribution();
     auto local_shape = tensor_shape;

--- a/include/lbann/layers/io/input/generic_input_layer.hpp
+++ b/include/lbann/layers/io/input/generic_input_layer.hpp
@@ -886,7 +886,15 @@ class generic_input_layer : public io_layer {
     // also enabled for distconv
     if (get_num_children() == 2 && get_child_layers()[1]->using_distconv()) {
       m_copy_labels_dc = true;
+      dc::MPIRootPrintStreamInfo() << "Copy label/response data to Distconv as well";
     }
+
+#if 0
+    auto mb_shape = get_output_dims(0);
+    dc::MPIRootPrintStreamInfo() << "Mini-batch shape: "
+                                 << dc::util::tostring(mb_shape.begin(),
+                                                       mb_shape.end());
+#endif
 
     const auto tensor_shape = get_output_tensor_shape();
     const Dist sample_dist = Layer::get_hydrogen_matrix_distribution();
@@ -1236,6 +1244,8 @@ class generic_input_layer : public io_layer {
     m_labels_dev = TensorDev(tensor_shape, loc, dist);
     assert0(m_labels_dev.allocate());
     m_labels_dev.zero(dc::get_stream());
+
+    dc::MPIRootPrintStreamInfo() << "label tensor: " << m_labels_dev;
   }
 
   void copy_label_distconv(int mb_size) {

--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -573,7 +573,7 @@ protected:
   virtual size_t estimate_memory_usage(const std::array<dc::Dist, dc::num_dists> &dists);
   /** Return Distconv-related shapes. */
   const dc::Shape get_input_tensor_shape() const;
-  const dc::Shape get_output_tensor_shape() const;
+  const dc::Shape get_output_tensor_shape(int output_index = 0) const;
   virtual void setup_tensors_fwd(const std::array<dc::Dist, dc::num_dists> &dists) {}
   virtual void setup_prev_activations_tensor(const std::array<dc::Dist, dc::num_dists> &dists);
   virtual dc::Shape get_activations_tensor_local_shape() const;
@@ -587,7 +587,7 @@ protected:
   virtual void setup_error_signals_copyout_tensor(const std::array<dc::Dist, dc::num_dists> &dists);
 
   // REFACTORING: returning non-const tensor should be protected
-  virtual const dc::TensorDev &get_activations_t() const;
+  virtual const dc::TensorDev &get_activations_t(const Layer &child) const;
   virtual const dc::TensorDev &get_error_signals_t() const;
   virtual const dc::TensorDev &get_error_signals_t(const Layer &parent) const;
   //virtual ConstTensorDev get_activations_const_view() const;

--- a/include/lbann/layers/loss/cross_entropy.hpp
+++ b/include/lbann/layers/loss/cross_entropy.hpp
@@ -249,7 +249,7 @@ private:
     setup_prev_activations_tensor(dists);
     setup_activations_tensor(dists);
     setup_activations_copyout_tensor(dists);
-    m_ground_truth_t = get_parent_layers()[1]->get_activations_t();
+    m_ground_truth_t = get_parent_layers()[1]->get_activations_t(*this);
   }
 
   void setup_tensors_bwd(const std::array<dc::Dist, dc::num_dists> &dists)

--- a/include/lbann/layers/transform/concatenation.hpp
+++ b/include/lbann/layers/transform/concatenation.hpp
@@ -335,9 +335,8 @@ private:
                   !m_parent_copy_in_required);
     m_prev_activations_siblings.reserve(get_num_parents() - 1);
     for (int i = 0; i < get_num_parents() - 1; ++i) {
-      // TODO: Think about the parent has two output tensors (e.g., split).
       m_prev_activations_siblings.emplace_back(
-          get_parent_layers()[i+1]->get_activations_t());
+          get_parent_layers()[i+1]->get_activations_t(*this));
     }
   }
 

--- a/include/lbann/layers/transform/split.hpp
+++ b/include/lbann/layers/transform/split.hpp
@@ -91,6 +91,11 @@ protected:
 
  public:
 
+  const dc::TensorDev &get_activations_t(const Layer &child) const {
+    // Pass the same tensor as a const reference to multiple child layers
+    return m_activations_t;
+  }
+
   void setup_tensor_distribution_init(
       std::map<const Layer*, std::array<lbann::dc::Dist, dc::num_dists>> &dists,
       std::map<dc::Dist*, std::set<dc::Dist*>> &invariants,

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -141,9 +141,8 @@ protected:
                   !m_parent_copy_in_required);
     m_prev_activations_siblings.reserve(get_num_parents() - 1);
     for (int i = 1; i < get_num_parents(); ++i) {
-     // TODO: Think about the parent has two output tensors (e.g., split).
       m_prev_activations_siblings.emplace_back(
-          get_parent_layers()[i]->get_activations_t());
+          get_parent_layers()[i]->get_activations_t(*this));
     }
   }
 

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1590,8 +1590,7 @@ void Layer::setup_prev_activations_tensor(const std::array<Dist, dc::num_dists> 
                                                 sample_dist,
                                                 input_local_shape);
     } else {
-      // TODO: Think about the parent has two output tensors (e.g., split).
-      m_prev_activations_const_view = get_parent_layers()[0]->get_activations_t();
+      m_prev_activations_const_view = get_parent_layers()[0]->get_activations_t(*this);
     }
     m_prev_activations_t = TensorDev(input_tensor_shape, loc, dists[0]);
     assert0(m_prev_activations_t.allocate());
@@ -1603,7 +1602,7 @@ void Layer::setup_prev_activations_tensor(const std::array<Dist, dc::num_dists> 
     }
   } else {
     // TODO: Think about the parent has two output tensors (e.g., split).
-    m_prev_activations_t = get_parent_layers()[0]->get_activations_t();
+    m_prev_activations_t = get_parent_layers()[0]->get_activations_t(*this);
     assert_always(m_prev_activations_t.get_distribution() == dists[0]);
   }
 
@@ -1728,7 +1727,8 @@ void Layer::setup_error_signals_copyout_tensor(const std::array<Dist, dc::num_di
   }
 }
 
-const TensorDev &Layer::get_activations_t() const {
+const TensorDev &Layer::get_activations_t(const Layer &child) const {
+  assert_always(get_num_children() == 1);
   return m_activations_t;
 }
 
@@ -1953,8 +1953,8 @@ const dc::Shape Layer::get_input_tensor_shape() const {
   input_tensor_shape_v.push_back(this->m_model->get_max_mini_batch_size());
   return dc::Shape(input_tensor_shape_v);
 }
-const dc::Shape Layer::get_output_tensor_shape() const {
-  const auto output_dims = get_output_dims();
+const dc::Shape Layer::get_output_tensor_shape(int output_index) const {
+  const auto output_dims = get_output_dims(output_index);
   std::vector<int> output_tensor_shape_v(output_dims.rbegin(), output_dims.rend());
   output_tensor_shape_v.push_back(this->m_model->get_max_mini_batch_size());
   return dc::Shape(output_tensor_shape_v);

--- a/src/layers/layer.cpp
+++ b/src/layers/layer.cpp
@@ -1372,6 +1372,11 @@ void Layer::setup_inter_layer_adaptation() {
       m_child_shuffle_required |= ps != c->get_parallel_strategy();
     }
   }
+  // If this layer is the last layer, copy the distconv tensor back to
+  // LBANN.
+  if (get_num_children() == 0) {
+    m_child_copy_out_required = true;
+  }
   m_child_shuffle_required |= m_child_copy_out_required;
   MPIRootPrintStreamInfo() << "m_child_copy_out_required: "
                            << m_child_copy_out_required

--- a/src/models/model.cpp
+++ b/src/models/model.cpp
@@ -1456,6 +1456,9 @@ void model::setup_distconv() {
         dc::MPIRootPrintStreamDebug() << "Invariant: " << *p << "\n";
         if (d->get_overlap() != p->get_overlap()) {
           if (fixed.find(p) != fixed.end()) {
+            dc::MPIRootPrintStreamError()
+                << "Incompatible distributions: "
+                << *d << " <=> " << *p;
             throw lbann_exception("Cannot satisfy the distconv constraints");
           }
           p->set_overlap(d->get_overlap());


### PR DESCRIPTION
The input layer copies and shuffles labels as well when the layer using them is also enabled for Distconv (i.e., parallel strategy is attached). In the U-Net example, this means that attaching a parallel strategy to the cross entropy layer.

Since LBANN does not provide the shape of a label, this PR uses several temporary hacks that should work for the U-Net model but not necessarily for other models.

The changes here should not have any impact when the label data is not copied to Distconv.