### PR TITLE
Per-edge copyin and copyout

### DIFF
--- a/include/lbann/layers/layer.hpp
+++ b/include/lbann/layers/layer.hpp
@@ -600,10 +600,20 @@ protected:
   virtual int get_num_spatial_dims() const;
 
  protected:
-  virtual bool keep_original_input() const { return m_keep_original_input; }
-  virtual bool keep_original_output() const { return m_keep_original_output; }
+  virtual bool keep_original_input(int input_index) const {
+    return m_keep_original_input[input_index];
+  }
+  virtual bool keep_original_output(int output_index) const {
+    return m_keep_original_output[output_index];
+  }
   virtual bool keep_original() const {
-    return keep_original_input() && keep_original_output();
+    for (int i = 0; i < get_num_parents(); ++i) {
+      if (!keep_original_input(i)) return false;
+    }
+    for (int i = 0; i < get_num_children(); ++i) {
+      if (!keep_original_output(i)) return false;
+    }
+    return true;
   }
   virtual void fp_setup_distconv(int mini_batch_size);
   virtual void bp_setup_distconv(int mini_batch_size);
@@ -650,10 +660,10 @@ protected:
                 get_name() + "_error_signals_original");
   }
 
-  bool m_parent_copy_in_required = false;
-  bool m_parent_shuffle_required = false;
-  bool m_child_copy_out_required = false;
-  bool m_child_shuffle_required = false;
+  std::vector<bool> m_parent_copy_in_required;
+  std::vector<bool> m_parent_shuffle_required;
+  std::vector<bool> m_child_copy_out_required;
+  std::vector<bool> m_child_shuffle_required;
   /** Previous activation tensor */
   dc::TensorDev m_prev_activations_t;
   /** View to Elemental matrix of previous activations */
@@ -680,8 +690,8 @@ protected:
   dc::TensorShuffler *m_error_signals_shuffler_last_mb[3];
  private:
   bool m_distconv_enabled = false;
-  bool m_keep_original_input = true;
-  bool m_keep_original_output = true;
+  std::vector<bool> m_keep_original_input;
+  std::vector<bool> m_keep_original_output;
 #endif // LBANN_HAS_DISTCONV
 
 private:

--- a/include/lbann/layers/transform/split.hpp
+++ b/include/lbann/layers/transform/split.hpp
@@ -130,13 +130,11 @@ protected:
     this->setup_error_signals_tensor(dists);
     this->setup_error_signals_copyout_tensor(dists);
 
-    // Setup copy views for other child layers. Assuming the child
-    // layers are also distconv-enabled and using the same parallel
-    // strategy.
-    assert_always(!m_child_shuffle_required &&
-                  !m_child_copy_out_required);
     m_prev_error_signals_siblings.reserve(get_num_children() - 1);
     for (int i = 1; i < get_num_children(); ++i) {
+      if (m_child_shuffle_required[i] || m_child_copy_out_required[i]) {
+        LBANN_ERROR("Copyout non-first tensor not supported");
+      }
       m_prev_error_signals_siblings.emplace_back(
           get_child_layers()[i]->get_error_signals_t(*this));
     }

--- a/include/lbann/layers/transform/sum.hpp
+++ b/include/lbann/layers/transform/sum.hpp
@@ -137,10 +137,12 @@ protected:
     this->setup_activations_tensor(dists);
     this->setup_activations_copyout_tensor(dists);
 
-    assert_always(!m_parent_shuffle_required &&
-                  !m_parent_copy_in_required);
     m_prev_activations_siblings.reserve(get_num_parents() - 1);
     for (int i = 1; i < get_num_parents(); ++i) {
+      if (m_parent_shuffle_required[i] ||
+          m_parent_copy_in_required[i]) {
+        LBANN_ERROR("Copyin non-first tensor not supported");
+      }
       m_prev_activations_siblings.emplace_back(
           get_parent_layers()[i]->get_activations_t(*this));
     }


### PR DESCRIPTION
Tensor copyin and copyout originally only considered a single parent or
child. This commit partially addresses the case where layers have
multiple parents or children.